### PR TITLE
backend/gl: ensure to reset the program when reconfiguring

### DIFF
--- a/libnodegl/backend_gl.c
+++ b/libnodegl/backend_gl.c
@@ -345,6 +345,8 @@ static int gl_reconfigure(struct ngl_ctx *s, const struct ngl_config *config)
     struct graphicconfig *graphicconfig = &s->graphicconfig;
     memcpy(graphicconfig->scissor, scissor, sizeof(scissor));
 
+    s->program_id = 0;
+
     return 0;
 }
 


### PR DESCRIPTION
The program where not bind anymore if reconfuring and having the same program id. This generated GL_INVALID_OPERATION when trying to upload uniform