### PR TITLE
utils: rename Exporter.finished() signal

### DIFF
--- a/pynodegl-utils/pynodegl_utils/export.py
+++ b/pynodegl-utils/pynodegl_utils/export.py
@@ -35,7 +35,7 @@ class Exporter(QtCore.QThread):
 
     progressed = QtCore.Signal(int)
     failed = QtCore.Signal()
-    finished = QtCore.Signal()
+    export_finished = QtCore.Signal()
 
     def __init__(self, get_scene_func, filename, w, h, extra_enc_args=None, time=None):
         super(Exporter, self).__init__()
@@ -61,7 +61,7 @@ class Exporter(QtCore.QThread):
         else:
             ok = self._export(filename, width, height, self._extra_enc_args)
         if ok:
-            self.finished.emit()
+            self.export_finished.emit()
 
     def _export(self, filename, width, height, extra_enc_args=None):
         fd_r, fd_w = os.pipe()

--- a/pynodegl-utils/pynodegl_utils/ui/export_view.py
+++ b/pynodegl-utils/pynodegl_utils/ui/export_view.py
@@ -156,7 +156,7 @@ class ExportView(QtWidgets.QWidget):
         self._pgd.canceled.connect(self._cancel)
         self._exporter.progressed.connect(self._progress)
         self._exporter.failed.connect(self._fail)
-        self._exporter.finished.connect(self._finish)
+        self._exporter.export_finished.connect(self._finish)
 
         self._exporter.start()
 


### PR DESCRIPTION
There is already a QThread.finished() signal that is emitted
automatically when the thread exits:
https://doc.qt.io/qt-5/qthread.html#finished

In PyQt5 you could overwrite parent classes signals. With PySide2 the
existing QThread.finished() is still triggered, even though we could
think it was overwritten by Exporter.finished(), leading to connected
slots being called twice.

In the case of Exporter.finished(), the signal must only be emitted if the
export actually succeeded. Hence the chosen solution here is to rename
the signal to Exporter.export_finished().