### PR TITLE
Mrs/ci

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,0 +1,32 @@
+name: 'tests Linux'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  build_libs:
+
+    runs-on: ubuntu-18.04
+    container: ubuntu:19.10
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://ubuntu:19.10
+
+    - name: Install dependencies
+      run: |
+        apt -y --force-yes update
+        apt -y install build-essential
+        apt -y install curl pkg-config libglfw3-dev python-pip python2.7-dev python-virtualenv
+        apt -y install ffmpeg libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
+
+    - name: Build
+      run: |
+        make -j$(($(nproc)+1))
+    - name: Run tests
+      run: |
+        make -k -j$(($(nproc)+1)) tests
+

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -1,0 +1,27 @@
+name: 'tests Mac'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  build_libs:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: |
+        brew update
+        brew upgrade
+        brew install python2 curl pkg-config glfw3 ffmpeg
+        sudo pip install virtualenv
+
+    - name: Build
+      run: |
+        make -j$(($(sysctl -n hw.logicalcpu)+1))
+


### PR DESCRIPTION
This branche adds two files corresponding to a pipeline in YAML format into the hidden repository ".github/workflows/" :
- ci_mac.yml (run CI on macOS 10.15.1: build node.gl)
- ci_linux.yml (run CI on Ubuntu 18.04 with a Docker on Ubuntu 19.10: build node.gl and run tests without graphic context)

Every workflow is triggered at each Pull Request and for each Push on Master.

You also have to add the statut badge at the beggining on your README but the repo path is hardcoded inside it so I can't do it in this PR:
Please, follow this example : 

`[![Actions Status](https://github.com/mrobertseidowsky-gpsw/node.gl.ci/workflows/Continuous%20Integration%20Pipeline/badge.svg)](https://github.com/mrobertseidowsky-gpsw/node.gl.ci/actions?query=workflow%3AContinuous%20Integration%20Pipeline)
`


To block the merge of PR is ci_mac.yml and ci_linux.yml are failing, please follow: https://help.github.com/en/github/administering-a-repository/enabling-required-status-checks
I can show you my configuration if needed. 

Example of workflow in fail statut on a PR (since I'm admin I can merge it even in fail case) : 

 ![merge_ko](https://user-images.githubusercontent.com/56554183/73657864-71b44d80-4693-11ea-89b9-1dd3033ffc15.png)

Example of workflow in success statut on a PR : 

 
![merge_ok](https://user-images.githubusercontent.com/56554183/73658062-e2f40080-4693-11ea-97c0-4e5932a8ae79.png)





General information about limitations of free Github Actions are:

- 20 workflows/concurrent jobs per repo,
- 6h execution per workflow max,
- 1000 API request per hour max in one repo,
- And one big limitation to my point of view is that we CAN NOT delete one workflow runs so we have the whole history and it can become fast pretty ugly... so test workflows files on forked repo before.

 