### PR TITLE
Mrs/coverage badge

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -1,0 +1,35 @@
+name: 'coverage tests Linux'
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build_libs:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y update
+        sudo apt -y install libsdl2-dev python3-venv gcovr
+        sudo apt -y install ffmpeg libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
+
+    - name: Run tests with GL backend
+      run: |
+        export CFLAGS=-fPIE
+        DISABLE_TESTS_SAMPLES=yes DISABLE_TESTS_STD430=yes BACKEND=gl DEBUG=yes DEBUG_GL=yes make -k -j$(($(nproc)+1)) tests COVERAGE=yes
+    - name: Run tests with GLES backend
+      run: |
+        DISABLE_TESTS_SAMPLES=yes DISABLE_TESTS_STD430=yes BACKEND=gles DEBUG=yes DEBUG_GL=yes make -k -j$(($(nproc)+1)) tests COVERAGE=yes
+    - name: Get coverage
+      run: |
+        gcovr -r libnodegl -s -x -o coverage.xml
+        make clean
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: coverage.xml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and API can change at any time.
 
 ![tests Linux](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Linux/badge.svg)
 ![tests Mac](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Mac/badge.svg)
+[![coverage](https://codecov.io/gh/gopro/gopro-lib-node.gl/branch/master/graph/badge.svg)](https://codecov.io/gh/gopro/gopro-lib-node.gl)
 
 [gopro]: https://gopro.com/
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+  max_report_age: 168  # Coverage reports expire after one week.
+
+# Keep only relevant files, see doc: https://docs.codecov.io/docs/fixing-paths
+codecov:
+  disable_default_path_fixes: yes
+fixes:
+  - "libnodegl::"


### PR DESCRIPTION
- Rebased on master.

- This PR allows to get a coverage badge which links to codecov.io and show a coverage report.

- The below error from codecov is due to the fact that coverage is send to codecov only on master branch, not PR branch (`strict_yaml_branch: master `in config codecov.yml)

- This branch has been tested OK on my forked repository: 
 [Test on Ubuntu 20.04](https://github.com/mrobertseidowsky-gpsw/gopro-lib-node.gl/runs/735052778?check_suite_focus=true)

- _Note_: **Codecov** computes the coverage in this way: `hits / (hits + misses + partials)`
Whereas **gcovr** computes the coverage in this way: `(hits + partials) / (hits + misses + partials)` _i.e_ partials are included as hits.
Partials are part of the source code which is not fully executed by the test suite; there are remaining branches that were not executed. 
See [related ticket](https://community.codecov.io/t/missing-information-into-coverage-xml-uploaded-file/1470/3)