### PR TITLE
ci: Upgrade docker on Ubuntu 20.04 for tests.

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -9,18 +9,14 @@ on:
 jobs:
   build_libs:
 
-    runs-on: ubuntu-18.04
-    container: ubuntu:19.10
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://ubuntu:19.10
 
     - name: Install dependencies
       run: |
-        apt -y --force-yes update
-        apt -y install build-essential
-
+        sudo apt -y update
         #
         # python3-venv is required to prevent the following issue:
         #     The virtual environment was not created successfully because ensurepip is not
@@ -29,8 +25,8 @@ jobs:
         #
         #         apt-get install python3-venv
         #
-        apt -y install curl pkg-config libsdl2-dev python3-pip python3-dev python3-venv
-        apt -y install ffmpeg libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
+        sudo apt -y install libsdl2-dev python3-venv
+        sudo apt -y install ffmpeg libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
 
     - name: Build
       run: |

--- a/pynodegl/requirements.txt
+++ b/pynodegl/requirements.txt
@@ -2,3 +2,5 @@
 # should be enough, it actually isn't due to Extension() not recognizing the
 # .pyx extension before it honors the dependencies.
 cython>=0.29.6
+# Workaround for the following issue on Ubuntu 20.04: "error: invalid command 'bdist_wheel'"
+wheel


### PR DESCRIPTION
- As reported when I migrated from Ubuntu 19.0 to Ubuntu 20.04, **wheel** was needed into `pynodegl/requirements.txt`.

- Also, **tzdata** installation is needed before **build-essential** to avoid an interactiv dialog blocker.

- This branch has been tested OK on my forked repository: 
[Test on Ubuntu 20.04](https://github.com/mrobertseidowsky-gpsw/gopro-lib-node.gl/runs/731136538?check_suite_focus=true)