### PR TITLE
ci: fix path for codecov coverage badge service

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ codecov:
 codecov:
   disable_default_path_fixes: yes
 fixes:
-  - "libnodegl::"
+  - "::libnodegl/"


### PR DESCRIPTION
- Fix the "404 not found" issue on coverage files on codecov.
- Taking into account feedback https://community.codecov.io/t/missing-information-into-coverage-xml-uploaded-file/1470/8 
- See doc on path fixing: https://docs.codecov.io/docs/fixing-paths
- Tests OK on my forked repo, [example](https://codecov.io/gh/mrobertseidowsky-gpsw/gopro-lib-node.gl/src/46c87cde9c30a0e83aa3d6958ba0ce6f34490e4a/libnodegl/buffer.c)