### PR TITLE
tests: use AnimatedVec4 instead of AnimatedVec3 for tests

### DIFF
--- a/libnodegl/doc/libnodegl.md
+++ b/libnodegl/doc/libnodegl.md
@@ -601,7 +601,7 @@ Parameter | Ctor. | Live-chg. | Type | Description | Default
 `wrap_s` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the s dimension (horizontal) | `clamp_to_edge`
 `wrap_t` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the t dimension (vertical) | `clamp_to_edge`
 `access` |  |  | [`access`](#access-choices) | texture access (only honored by the `Compute` node) | `read+write`
-`data_src` |  |  | [`Node`](#parameter-types) ([Media](#media), [AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec3](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec3](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec3](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec3](#buffer), [BufferVec4](#buffer)) | data source | 
+`data_src` |  |  | [`Node`](#parameter-types) ([Media](#media), [AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec4](#buffer)) | data source | 
 `direct_rendering` |  |  | [`bool`](#parameter-types) | whether direct rendering is allowed or not for media playback | `1`
 
 
@@ -623,7 +623,7 @@ Parameter | Ctor. | Live-chg. | Type | Description | Default
 `wrap_t` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the t dimension (vertical) | `clamp_to_edge`
 `wrap_r` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the r dimension (depth) | `clamp_to_edge`
 `access` |  |  | [`access`](#access-choices) | texture access (only honored by the `Compute` node) | `read+write`
-`data_src` |  |  | [`Node`](#parameter-types) ([AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec3](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec3](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec3](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec3](#buffer), [BufferVec4](#buffer)) | data source | 
+`data_src` |  |  | [`Node`](#parameter-types) ([AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec4](#buffer)) | data source | 
 
 
 **Source**: [node_texture.c](/libnodegl/node_texture.c)
@@ -642,7 +642,7 @@ Parameter | Ctor. | Live-chg. | Type | Description | Default
 `wrap_t` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the t dimension (vertical) | `clamp_to_edge`
 `wrap_r` |  |  | [`wrap`](#wrap-choices) | wrap parameter for the texture on the r dimension (depth) | `clamp_to_edge`
 `access` |  |  | [`access`](#access-choices) | texture access (only honored by the `Compute` node) | `read+write`
-`data_src` |  |  | [`Node`](#parameter-types) ([AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec3](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec3](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec3](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec3](#buffer), [BufferVec4](#buffer)) | data source | 
+`data_src` |  |  | [`Node`](#parameter-types) ([AnimatedBufferFloat](#animatedbuffer), [AnimatedBufferVec2](#animatedbuffer), [AnimatedBufferVec4](#animatedbuffer), [BufferByte](#buffer), [BufferBVec2](#buffer), [BufferBVec4](#buffer), [BufferInt](#buffer), [BufferIVec2](#buffer), [BufferIVec4](#buffer), [BufferShort](#buffer), [BufferSVec2](#buffer), [BufferSVec4](#buffer), [BufferUByte](#buffer), [BufferUBVec2](#buffer), [BufferUBVec4](#buffer), [BufferUInt](#buffer), [BufferUIVec2](#buffer), [BufferUIVec4](#buffer), [BufferUShort](#buffer), [BufferUSVec2](#buffer), [BufferUSVec4](#buffer), [BufferFloat](#buffer), [BufferVec2](#buffer), [BufferVec4](#buffer)) | data source | 
 
 
 **Source**: [node_texture.c](/libnodegl/node_texture.c)
@@ -1502,9 +1502,6 @@ Constant | Description
 `r32g32_uint` | 32-bit unsigned integer RG components
 `r32g32_sint` | 32-bit signed integer RG components
 `r32g32_sfloat` | 32-bit signed float RG components
-`r32g32b32_uint` | 32-bit unsigned integer RGB components
-`r32g32b32_sint` | 32-bit signed integer RGB components
-`r32g32b32_sfloat` | 32-bit signed float RGB components
 `r32g32b32a32_uint` | 32-bit unsigned integer RGBA components
 `r32g32b32a32_sint` | 32-bit signed integer RGBA components
 `r32g32b32a32_sfloat` | 32-bit signed float RGBA components

--- a/libnodegl/node_texture.c
+++ b/libnodegl/node_texture.c
@@ -114,9 +114,6 @@ static const struct param_choices format_choices = {
         {"r32g32_uint",          NGLI_FORMAT_R32G32_UINT,         .desc=NGLI_DOCSTRING("32-bit unsigned integer RG components")},
         {"r32g32_sint",          NGLI_FORMAT_R32G32_SINT,         .desc=NGLI_DOCSTRING("32-bit signed integer RG components")},
         {"r32g32_sfloat",        NGLI_FORMAT_R32G32_SFLOAT,       .desc=NGLI_DOCSTRING("32-bit signed float RG components")},
-        {"r32g32b32_uint",       NGLI_FORMAT_R32G32B32_UINT,      .desc=NGLI_DOCSTRING("32-bit unsigned integer RGB components")},
-        {"r32g32b32_sint",       NGLI_FORMAT_R32G32B32_SINT,      .desc=NGLI_DOCSTRING("32-bit signed integer RGB components")},
-        {"r32g32b32_sfloat",     NGLI_FORMAT_R32G32B32_SFLOAT,    .desc=NGLI_DOCSTRING("32-bit signed float RGB components")},
         {"r32g32b32a32_uint",    NGLI_FORMAT_R32G32B32A32_UINT,   .desc=NGLI_DOCSTRING("32-bit unsigned integer RGBA components")},
         {"r32g32b32a32_sint",    NGLI_FORMAT_R32G32B32A32_SINT,   .desc=NGLI_DOCSTRING("32-bit signed integer RGBA components")},
         {"r32g32b32a32_sfloat",  NGLI_FORMAT_R32G32B32A32_SFLOAT, .desc=NGLI_DOCSTRING("32-bit signed float RGBA components")},
@@ -138,14 +135,12 @@ static const struct param_choices format_choices = {
 #define BUFFER_NODES                \
     NGL_NODE_ANIMATEDBUFFERFLOAT,   \
     NGL_NODE_ANIMATEDBUFFERVEC2,    \
-    NGL_NODE_ANIMATEDBUFFERVEC3,    \
     NGL_NODE_ANIMATEDBUFFERVEC4,    \
     NGL_NODE_BUFFERBYTE,            \
     NGL_NODE_BUFFERBVEC2,           \
     NGL_NODE_BUFFERBVEC4,           \
     NGL_NODE_BUFFERINT,             \
     NGL_NODE_BUFFERIVEC2,           \
-    NGL_NODE_BUFFERIVEC3,           \
     NGL_NODE_BUFFERIVEC4,           \
     NGL_NODE_BUFFERSHORT,           \
     NGL_NODE_BUFFERSVEC2,           \
@@ -155,14 +150,12 @@ static const struct param_choices format_choices = {
     NGL_NODE_BUFFERUBVEC4,          \
     NGL_NODE_BUFFERUINT,            \
     NGL_NODE_BUFFERUIVEC2,          \
-    NGL_NODE_BUFFERUIVEC3,          \
     NGL_NODE_BUFFERUIVEC4,          \
     NGL_NODE_BUFFERUSHORT,          \
     NGL_NODE_BUFFERUSVEC2,          \
     NGL_NODE_BUFFERUSVEC4,          \
     NGL_NODE_BUFFERFLOAT,           \
     NGL_NODE_BUFFERVEC2,            \
-    NGL_NODE_BUFFERVEC3,            \
     NGL_NODE_BUFFERVEC4,            \
 
 
@@ -277,14 +270,12 @@ static int texture_prefetch(struct ngl_node *node)
             return 0;
         case NGL_NODE_ANIMATEDBUFFERFLOAT:
         case NGL_NODE_ANIMATEDBUFFERVEC2:
-        case NGL_NODE_ANIMATEDBUFFERVEC3:
         case NGL_NODE_ANIMATEDBUFFERVEC4:
         case NGL_NODE_BUFFERBYTE:
         case NGL_NODE_BUFFERBVEC2:
         case NGL_NODE_BUFFERBVEC4:
         case NGL_NODE_BUFFERINT:
         case NGL_NODE_BUFFERIVEC2:
-        case NGL_NODE_BUFFERIVEC3:
         case NGL_NODE_BUFFERIVEC4:
         case NGL_NODE_BUFFERSHORT:
         case NGL_NODE_BUFFERSVEC2:
@@ -294,14 +285,12 @@ static int texture_prefetch(struct ngl_node *node)
         case NGL_NODE_BUFFERUBVEC4:
         case NGL_NODE_BUFFERUINT:
         case NGL_NODE_BUFFERUIVEC2:
-        case NGL_NODE_BUFFERUIVEC3:
         case NGL_NODE_BUFFERUIVEC4:
         case NGL_NODE_BUFFERUSHORT:
         case NGL_NODE_BUFFERUSVEC2:
         case NGL_NODE_BUFFERUSVEC4:
         case NGL_NODE_BUFFERFLOAT:
         case NGL_NODE_BUFFERVEC2:
-        case NGL_NODE_BUFFERVEC3:
         case NGL_NODE_BUFFERVEC4: {
             struct buffer_priv *buffer = s->data_src->priv_data;
 
@@ -387,7 +376,6 @@ static int texture_update(struct ngl_node *node, double t)
             break;
         case NGL_NODE_ANIMATEDBUFFERFLOAT:
         case NGL_NODE_ANIMATEDBUFFERVEC2:
-        case NGL_NODE_ANIMATEDBUFFERVEC3:
         case NGL_NODE_ANIMATEDBUFFERVEC4:
             ret = ngli_node_update(s->data_src, t);
             if (ret < 0)

--- a/pynodegl-utils/pynodegl_utils/examples/transforms.py
+++ b/pynodegl-utils/pynodegl_utils/examples/transforms.py
@@ -138,7 +138,7 @@ def animated_buffer(cfg, dim=50):
     time_scale = cfg.duration / float(nb_kf)
     for i, buf in enumerate(buffers + [buffers[0]]):
         random_animkf.append(ngl.AnimKeyFrameBuffer(i*time_scale, buf))
-    random_buffer = ngl.AnimatedBufferVec3(keyframes=random_animkf)
+    random_buffer = ngl.AnimatedBufferVec4(keyframes=random_animkf)
     random_tex = ngl.Texture2D(data_src=random_buffer, width=dim, height=dim)
 
     quad = ngl.Quad((-1, -1, 0), (2, 0, 0), (0, 2, 0))

--- a/pynodegl-utils/pynodegl_utils/examples/transforms.py
+++ b/pynodegl-utils/pynodegl_utils/examples/transforms.py
@@ -2,6 +2,7 @@ import array
 import random
 import pynodegl as ngl
 from pynodegl_utils.misc import scene
+from pynodegl_utils.toolbox.colors import get_random_color_buffer
 
 
 @scene(color=scene.Color(),
@@ -131,9 +132,8 @@ def animated_buffer(cfg, dim=50):
     cfg.duration = 5.
 
     random.seed(0)
-    get_rand = lambda: array.array('f', [random.random() for i in range(dim ** 2 * 3)])
     nb_kf = int(cfg.duration)
-    buffers = [get_rand() for i in range(nb_kf)]
+    buffers = [get_random_color_buffer(dim) for i in range(nb_kf)]
     random_animkf = []
     time_scale = cfg.duration / float(nb_kf)
     for i, buf in enumerate(buffers + [buffers[0]]):

--- a/pynodegl-utils/pynodegl_utils/toolbox/colors.py
+++ b/pynodegl-utils/pynodegl_utils/toolbox/colors.py
@@ -20,6 +20,10 @@
 # under the License.
 #
 
+import array
+import random
+
+
 # https://en.wikipedia.org/wiki/Color_term
 COLORS = {
     'white':   (1.0, 1.0, 1.0, 1.0),
@@ -37,3 +41,10 @@ COLORS = {
     'magenta': (1.0, 0.0, 1.0, 1.0),
     'rose':    (1.0, 0.0, 0.5, 1.0),
 }
+
+
+def get_random_color_buffer(dim):
+    data = []
+    for i in range(dim ** 2):
+        data += (random.random(), random.random(), random.random())
+    return array.array('f', data)

--- a/pynodegl-utils/pynodegl_utils/toolbox/colors.py
+++ b/pynodegl-utils/pynodegl_utils/toolbox/colors.py
@@ -46,5 +46,5 @@ COLORS = {
 def get_random_color_buffer(dim):
     data = []
     for i in range(dim ** 2):
-        data += (random.random(), random.random(), random.random())
+        data += (random.random(), random.random(), random.random(), 1.0)
     return array.array('f', data)

--- a/tests/shape.py
+++ b/tests/shape.py
@@ -26,6 +26,7 @@ import itertools
 import pynodegl as ngl
 from pynodegl_utils.misc import scene
 from pynodegl_utils.toolbox.colors import COLORS
+from pynodegl_utils.toolbox.colors import get_random_color_buffer
 from pynodegl_utils.tests.cmp_fingerprint import test_fingerprint
 from pynodegl_utils.toolbox.shapes import equilateral_triangle_coords
 from pynodegl_utils.toolbox.grid import autogrid_simple
@@ -252,10 +253,8 @@ def _get_cropboard_function(set_indices=False):
         cfg.duration = 5. + 1.
 
         random.seed(0)
-
-        get_rand = lambda: array.array('f', [random.random() for i in range(dim_clr ** 2 * 3)])
         nb_kf = 2
-        buffers = [get_rand() for i in range(nb_kf)]
+        buffers = [get_random_color_buffer(dim_clr) for i in range(nb_kf)]
         random_animkf = []
         time_scale = cfg.duration / float(nb_kf)
         for i, buf in enumerate(buffers + [buffers[0]]):

--- a/tests/shape.py
+++ b/tests/shape.py
@@ -259,7 +259,7 @@ def _get_cropboard_function(set_indices=False):
         time_scale = cfg.duration / float(nb_kf)
         for i, buf in enumerate(buffers + [buffers[0]]):
             random_animkf.append(ngl.AnimKeyFrameBuffer(i*time_scale, buf))
-        random_buffer = ngl.AnimatedBufferVec3(keyframes=random_animkf)
+        random_buffer = ngl.AnimatedBufferVec4(keyframes=random_animkf)
         random_tex = ngl.Texture2D(data_src=random_buffer, width=dim_clr, height=dim_clr)
 
         kw = kh = 1. / dim_cut

--- a/tests/texture.py
+++ b/tests/texture.py
@@ -62,7 +62,7 @@ def texture_data_animated(cfg, dim=8):
     time_scale = cfg.duration / float(nb_kf)
     for i, buf in enumerate(buffers + [buffers[0]]):
         random_animkf.append(ngl.AnimKeyFrameBuffer(i*time_scale, buf))
-    random_buffer = ngl.AnimatedBufferVec3(keyframes=random_animkf)
+    random_buffer = ngl.AnimatedBufferVec4(keyframes=random_animkf)
     random_tex = ngl.Texture2D(data_src=random_buffer, width=dim, height=dim)
     quad = ngl.Quad((-1, -1, 0), (2, 0, 0), (0, 2, 0))
     prog = ngl.Program(vertex=cfg.get_vert('texture'), fragment=cfg.get_frag('texture'))

--- a/tests/texture.py
+++ b/tests/texture.py
@@ -28,6 +28,7 @@ from pynodegl_utils.tests.debug import get_debug_points
 from pynodegl_utils.tests.cmp_fingerprint import test_fingerprint
 from pynodegl_utils.tests.cmp_cuepoints import test_cuepoints
 from pynodegl_utils.toolbox.colors import COLORS
+from pynodegl_utils.toolbox.colors import get_random_color_buffer
 
 
 def _render_buffer(cfg, w, h):
@@ -55,9 +56,8 @@ def texture_data(cfg, w=4, h=5):
 def texture_data_animated(cfg, dim=8):
     cfg.duration = 3.0
     random.seed(0)
-    get_rand = lambda: array.array('f', [random.random() for i in range(dim ** 2 * 3)])
     nb_kf = int(cfg.duration)
-    buffers = [get_rand() for i in range(nb_kf)]
+    buffers = [get_random_color_buffer(dim) for i in range(nb_kf)]
     random_animkf = []
     time_scale = cfg.duration / float(nb_kf)
     for i, buf in enumerate(buffers + [buffers[0]]):


### PR DESCRIPTION
The r32g32b32_sfloat format is not supported on AMD Polaris GPUs with
the Vulkan API.