### PR TITLE
glcontext_egl: rely on surfaceless contexts if available for all platforms

### DIFF
--- a/libnodegl/glcontext_egl.c
+++ b/libnodegl/glcontext_egl.c
@@ -449,7 +449,9 @@ static int egl_make_current(struct glcontext *ctx, int current)
 static void egl_swap_buffers(struct glcontext *ctx)
 {
     struct egl_priv *egl = ctx->priv_data;
-    eglSwapBuffers(egl->display, egl->surface);
+
+    if (!ctx->offscreen)
+        eglSwapBuffers(egl->display, egl->surface);
 }
 
 static int egl_set_swap_interval(struct glcontext *ctx, int interval)


### PR DESCRIPTION
Offscreen rendering relies on framebuffer objects and we should only create an unused pbuffer on context that do not support surfaceless context (to stay compatible with old drivers/devices). Moreover, Mesa 20.1.4 (on Arch Linux) broke pbuffer creation on Intel GPUs.