### PR TITLE
pipeline: decouples draw/dispatch parameters from the pipeline creation.

### DIFF
--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -70,6 +70,7 @@ struct gctx_class {
 
     struct pipeline *(*pipeline_create)(struct gctx *ctx);
     int (*pipeline_init)(struct pipeline *s, const struct pipeline_params *params);
+    int (*pipeline_update_attribute)(struct pipeline *s, int index, struct buffer *buffer);
     int (*pipeline_update_uniform)(struct pipeline *s, int index, const void *value);
     int (*pipeline_update_texture)(struct pipeline *s, int index, struct texture *texture);
     void (*pipeline_exec)(struct pipeline *s);

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -73,7 +73,9 @@ struct gctx_class {
     int (*pipeline_update_attribute)(struct pipeline *s, int index, struct buffer *buffer);
     int (*pipeline_update_uniform)(struct pipeline *s, int index, const void *value);
     int (*pipeline_update_texture)(struct pipeline *s, int index, struct texture *texture);
-    void (*pipeline_exec)(struct pipeline *s);
+    void (*pipeline_draw)(struct pipeline *s, int nb_vertices, int nb_instances);
+    void (*pipeline_draw_indexed)(struct pipeline *s, struct buffer *indices, int indices_format, int nb_indices, int nb_instances);
+    void (*pipeline_dispatch)(struct pipeline *s, int nb_group_x, int nb_group_y, int nb_group_z);
     void (*pipeline_freep)(struct pipeline **sp);
 
     struct program *(*program_create)(struct gctx *ctx);

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -637,6 +637,7 @@ const struct gctx_class ngli_gctx_gl = {
 
     .pipeline_create         = ngli_pipeline_gl_create,
     .pipeline_init           = ngli_pipeline_gl_init,
+    .pipeline_update_attribute = ngli_pipeline_gl_update_attribute,
     .pipeline_update_uniform = ngli_pipeline_gl_update_uniform,
     .pipeline_update_texture = ngli_pipeline_gl_update_texture,
     .pipeline_exec           = ngli_pipeline_gl_exec,
@@ -699,6 +700,7 @@ const struct gctx_class ngli_gctx_gles = {
 
     .pipeline_create         = ngli_pipeline_gl_create,
     .pipeline_init           = ngli_pipeline_gl_init,
+    .pipeline_update_attribute = ngli_pipeline_gl_update_attribute,
     .pipeline_update_uniform = ngli_pipeline_gl_update_uniform,
     .pipeline_update_texture = ngli_pipeline_gl_update_texture,
     .pipeline_exec           = ngli_pipeline_gl_exec,

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -640,7 +640,9 @@ const struct gctx_class ngli_gctx_gl = {
     .pipeline_update_attribute = ngli_pipeline_gl_update_attribute,
     .pipeline_update_uniform = ngli_pipeline_gl_update_uniform,
     .pipeline_update_texture = ngli_pipeline_gl_update_texture,
-    .pipeline_exec           = ngli_pipeline_gl_exec,
+    .pipeline_draw           = ngli_pipeline_gl_draw,
+    .pipeline_draw_indexed   = ngli_pipeline_gl_draw_indexed,
+    .pipeline_dispatch       = ngli_pipeline_gl_dispatch,
     .pipeline_freep          = ngli_pipeline_gl_freep,
 
     .program_create = ngli_program_gl_create,
@@ -703,7 +705,9 @@ const struct gctx_class ngli_gctx_gles = {
     .pipeline_update_attribute = ngli_pipeline_gl_update_attribute,
     .pipeline_update_uniform = ngli_pipeline_gl_update_uniform,
     .pipeline_update_texture = ngli_pipeline_gl_update_texture,
-    .pipeline_exec           = ngli_pipeline_gl_exec,
+    .pipeline_draw           = ngli_pipeline_gl_draw,
+    .pipeline_draw_indexed   = ngli_pipeline_gl_draw_indexed,
+    .pipeline_dispatch       = ngli_pipeline_gl_dispatch,
     .pipeline_freep          = ngli_pipeline_gl_freep,
 
     .program_create = ngli_program_gl_create,

--- a/libnodegl/hwconv.c
+++ b/libnodegl/hwconv.c
@@ -129,7 +129,6 @@ int ngli_hwconv_init(struct hwconv *hwconv, struct ngl_ctx *ctx,
         .type          = NGLI_PIPELINE_TYPE_GRAPHICS,
         .graphics      = {
             .topology    = NGLI_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
-            .nb_vertices = 4,
             .state       = ctx->graphicstate,
             .rt_desc     = rt_desc,
         },
@@ -216,7 +215,7 @@ int ngli_hwconv_convert_image(struct hwconv *hwconv, const struct image *image)
     ngli_pipeline_update_uniform(pipeline, fields[NGLI_INFO_FIELD_COORDINATE_MATRIX].index, image->coordinates_matrix);
     ngli_pipeline_update_uniform(pipeline, fields[NGLI_INFO_FIELD_COLOR_MATRIX].index, image->color_matrix);
 
-    ngli_pipeline_exec(hwconv->pipeline);
+    ngli_pipeline_draw(hwconv->pipeline, 4, 1);
 
     ngli_gctx_set_rendertarget(gctx, prev_rt);
     ngli_gctx_set_viewport(gctx, prev_vp);

--- a/libnodegl/node_hud.c
+++ b/libnodegl/node_hud.c
@@ -1332,7 +1332,6 @@ static int hud_init(struct ngl_node *node)
         .type          = NGLI_PIPELINE_TYPE_GRAPHICS,
         .graphics      = {
             .topology    = NGLI_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
-            .nb_vertices = 4,
             .state       = graphicstate,
             .rt_desc     = *ctx->rendertarget_desc,
         }
@@ -1412,7 +1411,7 @@ static void hud_draw(struct ngl_node *node)
     const float *projection_matrix = ngli_darray_tail(&ctx->projection_matrix_stack);
     ngli_pipeline_update_uniform(s->pipeline, s->modelview_matrix_index, modelview_matrix);
     ngli_pipeline_update_uniform(s->pipeline, s->projection_matrix_index, projection_matrix);
-    ngli_pipeline_exec(s->pipeline);
+    ngli_pipeline_draw(s->pipeline, 4, 1);
 }
 
 static void hud_uninit(struct ngl_node *node)

--- a/libnodegl/node_text.c
+++ b/libnodegl/node_text.c
@@ -319,7 +319,6 @@ static int text_prepare(struct ngl_node *node)
         .type          = NGLI_PIPELINE_TYPE_GRAPHICS,
         .graphics      = {
             .topology    = NGLI_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
-            .nb_vertices = 4,
             .state       = ctx->graphicstate,
             .rt_desc     = *ctx->rendertarget_desc,
         }
@@ -381,7 +380,7 @@ static void text_draw(struct ngl_node *node)
     ngli_pipeline_update_uniform(desc->pipeline, desc->modelview_matrix_index, modelview_matrix);
     ngli_pipeline_update_uniform(desc->pipeline, desc->projection_matrix_index, projection_matrix);
 
-    ngli_pipeline_exec(desc->pipeline);
+    ngli_pipeline_draw(desc->pipeline, 4, 1);
 }
 
 static void text_uninit(struct ngl_node *node)

--- a/libnodegl/pass.h
+++ b/libnodegl/pass.h
@@ -70,6 +70,10 @@ struct pass {
 
     struct ngl_node *indices;
     struct buffer *indices_buffer;
+    int indices_format;
+    int nb_indices;
+    int nb_vertices;
+    int nb_instances;
 
     int pipeline_type;
     struct pipeline_graphics pipeline_graphics;

--- a/libnodegl/pipeline.c
+++ b/libnodegl/pipeline.c
@@ -33,6 +33,11 @@ int ngli_pipeline_init(struct pipeline *s, const struct pipeline_params *params)
     return s->gctx->class->pipeline_init(s, params);
 }
 
+int ngli_pipeline_update_attribute(struct pipeline *s, int index, struct buffer *buffer)
+{
+    return s->gctx->class->pipeline_update_attribute(s, index, buffer);
+}
+
 int ngli_pipeline_update_uniform(struct pipeline *s, int index, const void *value)
 {
     return s->gctx->class->pipeline_update_uniform(s, index, value);

--- a/libnodegl/pipeline.c
+++ b/libnodegl/pipeline.c
@@ -48,9 +48,19 @@ int ngli_pipeline_update_texture(struct pipeline *s, int index, struct texture *
     return s->gctx->class->pipeline_update_texture(s, index, texture);
 }
 
-void ngli_pipeline_exec(struct pipeline *s)
+void ngli_pipeline_draw(struct pipeline *s, int nb_vertices, int nb_instances)
 {
-    s->gctx->class->pipeline_exec(s);
+    return s->gctx->class->pipeline_draw(s, nb_vertices, nb_instances);
+}
+
+void ngli_pipeline_draw_indexed(struct pipeline *s, struct buffer *indices, int indices_format, int nb_indices, int nb_instances)
+{
+    return s->gctx->class->pipeline_draw_indexed(s, indices, indices_format, nb_indices, nb_instances);
+}
+
+void ngli_pipeline_dispatch(struct pipeline *s, int nb_group_x, int nb_group_y, int nb_group_z)
+{
+    return s->gctx->class->pipeline_dispatch(s, nb_group_x, nb_group_y, nb_group_z);
 }
 
 void ngli_pipeline_freep(struct pipeline **sp)

--- a/libnodegl/pipeline.h
+++ b/libnodegl/pipeline.h
@@ -115,10 +115,12 @@ struct pipeline {
     struct darray texture_descs;
     struct darray buffer_descs;
     struct darray attribute_descs;
+    int nb_unbound_attributes;
 };
 
 struct pipeline *ngli_pipeline_create(struct gctx *gctx);
 int ngli_pipeline_init(struct pipeline *s, const struct pipeline_params *params);
+int ngli_pipeline_update_attribute(struct pipeline *s, int index, struct buffer *buffer);
 int ngli_pipeline_update_uniform(struct pipeline *s, int index, const void *value);
 int ngli_pipeline_update_texture(struct pipeline *s, int index, struct texture *texture);
 void ngli_pipeline_exec(struct pipeline *s);

--- a/libnodegl/pipeline.h
+++ b/libnodegl/pipeline.h
@@ -65,13 +65,6 @@ struct pipeline_attribute {
 
 struct pipeline_graphics {
     int topology;
-    union {
-        int nb_vertices;
-        int nb_indices;
-    };
-    int indices_format;
-    int nb_instances;
-    struct buffer *indices;
     struct graphicstate state;
     struct rendertarget_desc rt_desc;
 };
@@ -123,7 +116,10 @@ int ngli_pipeline_init(struct pipeline *s, const struct pipeline_params *params)
 int ngli_pipeline_update_attribute(struct pipeline *s, int index, struct buffer *buffer);
 int ngli_pipeline_update_uniform(struct pipeline *s, int index, const void *value);
 int ngli_pipeline_update_texture(struct pipeline *s, int index, struct texture *texture);
-void ngli_pipeline_exec(struct pipeline *s);
+void ngli_pipeline_draw(struct pipeline *s, int nb_vertices, int nb_instances);
+void ngli_pipeline_draw_indexed(struct pipeline *s, struct buffer *indices, int indices_format, int nb_indices, int nb_instances);
+void ngli_pipeline_dispatch(struct pipeline *s, int nb_group_x, int nb_group_y, int nb_group_z);
+
 void ngli_pipeline_freep(struct pipeline **sp);
 
 #endif

--- a/libnodegl/pipeline_gl.c
+++ b/libnodegl/pipeline_gl.c
@@ -484,7 +484,7 @@ static int pipeline_graphics_init(struct pipeline *s, const struct pipeline_para
     struct glcontext *gl = gctx_gl->glcontext;
     struct pipeline_graphics *graphics = &s->graphics;
 
-    if (graphics->nb_instances && !(gl->features & NGLI_FEATURE_DRAW_INSTANCED)) {
+    if (graphics->nb_instances > 1 && !(gl->features & NGLI_FEATURE_DRAW_INSTANCED)) {
         LOG(ERROR, "context does not support instanced draws");
         return NGL_ERROR_UNSUPPORTED;
     }
@@ -500,9 +500,9 @@ static int pipeline_graphics_init(struct pipeline *s, const struct pipeline_para
     }
 
     if (graphics->indices)
-        s_priv->exec = graphics->nb_instances > 0 ? draw_elements_instanced : draw_elements;
+        s_priv->exec = graphics->nb_instances > 1 ? draw_elements_instanced : draw_elements;
     else
-        s_priv->exec = graphics->nb_instances > 0 ? draw_arrays_instanced : draw_arrays;
+        s_priv->exec = graphics->nb_instances > 1 ? draw_arrays_instanced : draw_arrays;
 
     return 0;
 }

--- a/libnodegl/pipeline_gl.h
+++ b/libnodegl/pipeline_gl.h
@@ -38,6 +38,7 @@ struct pipeline_gl {
 
 struct pipeline *ngli_pipeline_gl_create(struct gctx *gctx);
 int ngli_pipeline_gl_init(struct pipeline *s, const struct pipeline_params *params);
+int ngli_pipeline_gl_update_attribute(struct pipeline *s, int index, struct buffer *buffer);
 int ngli_pipeline_gl_update_uniform(struct pipeline *s, int index, const void *value);
 int ngli_pipeline_gl_update_texture(struct pipeline *s, int index, struct texture *texture);
 void ngli_pipeline_gl_exec(struct pipeline *s);

--- a/libnodegl/pipeline_gl.h
+++ b/libnodegl/pipeline_gl.h
@@ -31,7 +31,6 @@ struct glcontext;
 struct pipeline_gl {
     struct pipeline parent;
 
-    void (*exec)(const struct pipeline *s, struct glcontext *gl);
     uint64_t used_texture_units;
     GLuint vao_id;
 };
@@ -41,7 +40,9 @@ int ngli_pipeline_gl_init(struct pipeline *s, const struct pipeline_params *para
 int ngli_pipeline_gl_update_attribute(struct pipeline *s, int index, struct buffer *buffer);
 int ngli_pipeline_gl_update_uniform(struct pipeline *s, int index, const void *value);
 int ngli_pipeline_gl_update_texture(struct pipeline *s, int index, struct texture *texture);
-void ngli_pipeline_gl_exec(struct pipeline *s);
+void ngli_pipeline_gl_draw(struct pipeline *s, int nb_vertices, int nb_instances);
+void ngli_pipeline_gl_draw_indexed(struct pipeline *s, struct buffer *indices, int indices_format, int nb_indices, int nb_instances);
+void ngli_pipeline_gl_dispatch(struct pipeline *s, int nb_group_x, int nb_group_y, int nb_group_z);
 void ngli_pipeline_gl_freep(struct pipeline **sp);
 
 #endif


### PR DESCRIPTION
Also allows attribute buffers to be set after pipeline creation.