### PR TITLE
tests/api: adjust clear color value

### DIFF
--- a/tests/api.py
+++ b/tests/api.py
@@ -67,9 +67,9 @@ def api_reconfigure_clearcolor(width=16, height=16):
     assert viewer.draw(0) == 0
     assert zlib.crc32(capture_buffer) == 0xb4bd32fa
     assert viewer.configure(offscreen=1, width=width, height=height, backend=_backend, capture_buffer=capture_buffer,
-                            clear_color=(0.3, 0.3, 0.3, 1.0)) == 0
+                            clear_color=(0.4, 0.4, 0.4, 1.0)) == 0
     assert viewer.draw(0) == 0
-    assert zlib.crc32(capture_buffer) == 0xfeb0bb01
+    assert zlib.crc32(capture_buffer) == 0x05c44869
     del capture_buffer
     del viewer
 


### PR DESCRIPTION
0.3 * 255 = 76.5, which can round to 0x4C or 0x4D depending on the
implementation. Use the unambigous 0.4 (0x66) instead.