### PR TITLE
graphicconfig: merge cull_face and cull_face_mode params

### DIFF
--- a/libnodegl/doc/libnodegl.md
+++ b/libnodegl/doc/libnodegl.md
@@ -319,8 +319,7 @@ Parameter | Live-chg. | Type | Description | Default
 `stencil_fail` |  | [`stencil_operation`](#stencil_operation-choices) | operation to execute if stencil test fails | `unset`
 `stencil_depth_fail` |  | [`stencil_operation`](#stencil_operation-choices) | operation to execute if depth test fails | `unset`
 `stencil_depth_pass` |  | [`stencil_operation`](#stencil_operation-choices) | operation to execute if stencil and depth test pass | `unset`
-`cull_face` |  | [`bool`](#parameter-types) | enable face culling | `unset`
-`cull_face_mode` |  | [`cull_face`](#cull_face-choices) | face culling mode | `unset`
+`cull_mode` |  | [`cull_mode`](#cull_mode-choices) | face culling mode | `unset`
 `scissor_test` |  | [`bool`](#parameter-types) | enable scissor testing | `unset`
 `scissor` |  | [`vec4`](#parameter-types) | define an area where all pixels outside are discarded | (`-1`,`-1`,`-1`,`-1`)
 
@@ -1395,7 +1394,7 @@ Constant | Description
 `decr_wrap` | decrements the current stencil buffer value and wraps it
 `decr_invert` | bitwise inverts the current stencil buffer value
 
-## cull_face choices
+## cull_mode choices
 
 Constant | Description
 -------- | -----------

--- a/libnodegl/glstate.c
+++ b/libnodegl/glstate.c
@@ -92,6 +92,7 @@ static GLenum get_gl_stencil_op(int stencil_op)
 }
 
 static const GLenum gl_cull_mode_map[NGLI_CULL_MODE_NB] = {
+    [NGLI_CULL_MODE_NONE]           = GL_BACK,
     [NGLI_CULL_MODE_FRONT_BIT]      = GL_FRONT,
     [NGLI_CULL_MODE_BACK_BIT]       = GL_BACK,
 };
@@ -166,8 +167,8 @@ static void init_state(struct glstate *s, const struct graphicstate *gc)
     s->stencil_depth_fail = get_gl_stencil_op(gc->stencil_depth_fail);
     s->stencil_depth_pass = get_gl_stencil_op(gc->stencil_depth_pass);
 
-    s->cull_face      = gc->cull_face;
-    s->cull_face_mode = get_gl_cull_mode(gc->cull_face_mode);
+    s->cull_face      = gc->cull_mode != NGLI_CULL_MODE_NONE;
+    s->cull_face_mode = get_gl_cull_mode(gc->cull_mode);
 
     s->scissor_test = gc->scissor_test;
 }

--- a/libnodegl/graphicstate.h
+++ b/libnodegl/graphicstate.h
@@ -109,8 +109,7 @@ struct graphicstate {
     int stencil_depth_fail;
     int stencil_depth_pass;
 
-    int cull_face;
-    int cull_face_mode;
+    int cull_mode;
 
     int scissor_test;
 };
@@ -138,8 +137,7 @@ struct graphicstate {
     .stencil_fail       = NGLI_STENCIL_OP_KEEP,            \
     .stencil_depth_fail = NGLI_STENCIL_OP_KEEP,            \
     .stencil_depth_pass = NGLI_STENCIL_OP_KEEP,            \
-    .cull_face          = 0,                               \
-    .cull_face_mode     = NGLI_CULL_MODE_BACK_BIT,         \
+    .cull_mode          = NGLI_CULL_MODE_NONE,             \
 }                                                          \
 
 #endif

--- a/libnodegl/node_graphicconfig.c
+++ b/libnodegl/node_graphicconfig.c
@@ -55,8 +55,7 @@ struct graphicconfig_priv {
     int stencil_depth_fail;
     int stencil_depth_pass;
 
-    int cull_face;
-    int cull_face_mode;
+    int cull_mode;
 
     int scissor_test;
     float scissor_f[4];
@@ -142,8 +141,8 @@ static const struct param_choices stencil_op_choices = {
     }
 };
 
-static const struct param_choices cull_face_choices = {
-    .name = "cull_face",
+static const struct param_choices cull_mode_choices = {
+    .name = "cull_mode",
     .consts = {
         {"unset", -1,                       .desc=NGLI_DOCSTRING("unset")},
         {"none",  NGLI_CULL_MODE_NONE,      .desc=NGLI_DOCSTRING("no facets are discarded")},
@@ -207,10 +206,8 @@ static const struct node_param graphicconfig_params[] = {
     {"stencil_depth_pass", PARAM_TYPE_SELECT, OFFSET(stencil_depth_pass), {.i64=-1},
                            .choices=&stencil_op_choices,
                            .desc=NGLI_DOCSTRING("operation to execute if stencil and depth test pass")},
-    {"cull_face",          PARAM_TYPE_BOOL,   OFFSET(cull_face),          {.i64=-1},
-                           .desc=NGLI_DOCSTRING("enable face culling")},
-    {"cull_face_mode",     PARAM_TYPE_SELECT, OFFSET(cull_face_mode),     {.i64=-1},
-                           .choices=&cull_face_choices,
+    {"cull_mode",          PARAM_TYPE_SELECT, OFFSET(cull_mode),          {.i64=-1},
+                           .choices=&cull_mode_choices,
                            .desc=NGLI_DOCSTRING("face culling mode")},
     {"scissor_test",       PARAM_TYPE_BOOL,   OFFSET(scissor_test),       {.i64=-1},
                            .desc=NGLI_DOCSTRING("enable scissor testing")},
@@ -228,11 +225,6 @@ static int graphicconfig_init(struct ngl_node *node)
     const float *sf = s->scissor_f;
     const int scissor[4] = {sf[0], sf[1], sf[2], sf[3]};
     memcpy(s->scissor, scissor, sizeof(s->scissor));
-
-    if (!s->cull_face_mode) {
-        LOG(ERROR, "cull face mode cannot be null");
-        return NGL_ERROR_INVALID_ARG;
-    }
 
     return 0;
 }
@@ -284,9 +276,8 @@ static void honor_config(struct ngl_node *node)
     COPY_PARAM(stencil_depth_fail);
     COPY_PARAM(stencil_depth_pass);
 
-    COPY_PARAM(cull_face);
-    if (s->cull_face_mode != -1)
-        pending->cull_face_mode = ngli_gctx_transform_cull_mode(gctx, s->cull_face_mode);
+    if (s->cull_mode != -1)
+        pending->cull_mode = ngli_gctx_transform_cull_mode(gctx, s->cull_mode);
 
     COPY_PARAM(scissor_test);
 }

--- a/libnodegl/nodes.specs
+++ b/libnodegl/nodes.specs
@@ -210,8 +210,7 @@
     - [stencil_fail, select]
     - [stencil_depth_fail, select]
     - [stencil_depth_pass, select]
-    - [cull_face, bool]
-    - [cull_face_mode, select]
+    - [cull_mode, select]
     - [scissor_test, bool]
     - [scissor, vec4]
 

--- a/tests/shape.py
+++ b/tests/shape.py
@@ -368,7 +368,7 @@ def shape_triangles_mat4_attribute(cfg):
     return render
 
 
-def _get_shape_scene(cfg, shape, cull_face_mode):
+def _get_shape_scene(cfg, shape, cull_mode):
     cfg.aspect_ratio = (1, 1)
 
     geometry_cls = dict(
@@ -379,17 +379,17 @@ def _get_shape_scene(cfg, shape, cull_face_mode):
     geometry = geometry_cls[shape]()
 
     node = _render_shape(cfg, geometry, COLORS['sgreen'])
-    return ngl.GraphicConfig(node, cull_face=True, cull_face_mode=cull_face_mode)
+    return ngl.GraphicConfig(node, cull_mode=cull_mode)
 
 
-def _get_shape_function(shape, cull_face_mode):
+def _get_shape_function(shape, cull_mode):
     @test_fingerprint()
     @scene()
     def shape_function(cfg):
-        return _get_shape_scene(cfg, shape, cull_face_mode)
+        return _get_shape_scene(cfg, shape, cull_mode)
     return shape_function
 
 
 for shape in ('triangle', 'quad', 'circle'):
-    for cull_face_mode in ('front', 'back'):
-        globals()['shape_' + shape + '_cull_' + cull_face_mode] = _get_shape_function(shape, cull_face_mode)
+    for cull_mode in ('front', 'back'):
+        globals()['shape_' + shape + '_cull_' + cull_mode] = _get_shape_function(shape, cull_mode)


### PR DESCRIPTION
Culling can either be unset, none (disabled), front (enabled) or back
(enabled).