### PR TITLE
gctx_gl: check capture_buffer before reading pixels

### DIFF
--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -50,7 +50,8 @@ static void capture_default(struct gctx *s)
     struct rendertarget *rt = s_priv->rt;
 
     ngli_rendertarget_resolve(rt);
-    ngli_rendertarget_read_pixels(rt, config->capture_buffer);
+    if (config->capture_buffer)
+        ngli_rendertarget_read_pixels(rt, config->capture_buffer);
 }
 
 static void capture_ios(struct gctx *s)


### PR DESCRIPTION
ngli_rendertarget_read_pixels() must not be called with data set to
NULL. This commit fixes a potential crash when node.gl is configured to
render offscreen and no capture_buffer is set.

Fixes a regression introduced by
0be6c0b929dfeade2bca163f36eabe963726b1f4.