### PR TITLE
rendertarget: move samples field from attachment_desc to rendertarget…

### DIFF
--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -270,12 +270,11 @@ static int gl_init(struct gctx *s)
     s->version = gl->version;
     s->features = gl->features;
     s->limits = gl->limits;
+    s_priv->default_rendertarget_desc.samples = gl->samples;
     s_priv->default_rendertarget_desc.nb_colors = 1;
     s_priv->default_rendertarget_desc.colors[0].format = NGLI_FORMAT_R8G8B8A8_UNORM;
-    s_priv->default_rendertarget_desc.colors[0].samples = gl->samples;
     s_priv->default_rendertarget_desc.colors[0].resolve = gl->samples > 1;
     s_priv->default_rendertarget_desc.depth_stencil.format = NGLI_FORMAT_D24_UNORM_S8_UINT;
-    s_priv->default_rendertarget_desc.depth_stencil.samples = gl->samples;
     s_priv->default_rendertarget_desc.depth_stencil.resolve = gl->samples > 1;
 
     ngli_glstate_probe(gl, &s_priv->glstate);

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -148,14 +148,15 @@ static int rtt_prepare(struct ngl_node *node)
         s->use_rt_resume = 1;
     }
 
-    struct rendertarget_desc desc = {0};
+    struct rendertarget_desc desc = {
+        .samples = s->samples,
+    };
     for (int i = 0; i < s->nb_color_textures; i++) {
         const struct texture_priv *texture_priv = s->color_textures[i]->priv_data;
         const struct texture_params *params = &texture_priv->params;
         const int faces = params->type == NGLI_TEXTURE_TYPE_CUBE ? 6 : 1;
         for (int j = 0; j < faces; j++) {
             desc.colors[desc.nb_colors].format = params->format;
-            desc.colors[desc.nb_colors].samples = s->samples;
             desc.colors[desc.nb_colors].resolve = s->samples > 1;
             desc.nb_colors++;
         }
@@ -164,7 +165,6 @@ static int rtt_prepare(struct ngl_node *node)
         const struct texture_priv *depth_texture_priv = s->depth_texture->priv_data;
         const struct texture_params *depth_texture_params = &depth_texture_priv->params;
         desc.depth_stencil.format = depth_texture_params->format;
-        desc.depth_stencil.samples = s->samples;
         desc.depth_stencil.resolve = s->samples > 1;
     } else {
         int depth_format = NGLI_FORMAT_UNDEFINED;
@@ -173,7 +173,6 @@ static int rtt_prepare(struct ngl_node *node)
         else if (s->features & FEATURE_DEPTH)
             depth_format = ngli_gctx_get_preferred_depth_format(gctx);
         desc.depth_stencil.format = depth_format;
-        desc.depth_stencil.samples = s->samples;
     }
     rnode->rendertarget_desc = desc;
 

--- a/libnodegl/rendertarget.h
+++ b/libnodegl/rendertarget.h
@@ -40,11 +40,11 @@ enum {
 
 struct attachment_desc {
     int format;
-    int samples;
     int resolve;
 };
 
 struct rendertarget_desc {
+    int samples;
     int nb_colors;
     struct attachment_desc colors[NGLI_MAX_COLOR_ATTACHMENTS];
     struct attachment_desc depth_stencil;


### PR DESCRIPTION
…_desc

All attachments must have the same samples count.