### PR TITLE
tests/rtt: add rtt_load_attachment test

### DIFF
--- a/tests/refs/rtt_load_attachment.ref
+++ b/tests/refs/rtt_load_attachment.ref
@@ -1,0 +1,1 @@
+bottom-left:FFFFFFFF top-right:FF8000FF

--- a/tests/rtt.mak
+++ b/tests/rtt.mak
@@ -20,6 +20,7 @@
 #
 
 RTT_TEST_NAMES =                         \
+    load_attachment                      \
     feature_depth                        \
     feature_depth_stencil                \
     mipmap                               \


### PR DESCRIPTION
Ensures that when a node rtt draw ends, we restore the previous
rendertarget without discarding its attachments.