### PR TITLE
rendertarget: add load and store operations

### DIFF
--- a/libnodegl/doc/libnodegl.md
+++ b/libnodegl/doc/libnodegl.md
@@ -455,7 +455,7 @@ Parameter | Live-chg. | Type | Description | Default
 `color_textures` |  | [`NodeList`](#parameter-types) ([Texture2D](#texture2d), [TextureCube](#texturecube)) | destination color texture | 
 `depth_texture` |  | [`Node`](#parameter-types) ([Texture2D](#texture2d)) | destination depth (and potentially combined stencil) texture | 
 `samples` |  | [`int`](#parameter-types) | number of samples used for multisampling anti-aliasing | `0`
-`clear_color` |  | [`vec4`](#parameter-types) | color used to clear the `color_texture` | (`-1`,`-1`,`-1`,`-1`)
+`clear_color` |  | [`vec4`](#parameter-types) | color used to clear the `color_texture` | (`0`,`0`,`0`,`0`)
 `features` |  | [`framebuffer_features`](#framebuffer_features-choices) | framebuffer feature mask | `0`
 `vflip` |  | [`bool`](#parameter-types) | apply a vertical flip to `color_texture` and `depth_texture` transformation matrices to match the `node.gl` uv coordinates system | `1`
 

--- a/libnodegl/doc/libnodegl.md
+++ b/libnodegl/doc/libnodegl.md
@@ -1390,7 +1390,6 @@ Constant | Description
 -------- | -----------
 `depth` | add depth buffer
 `stencil` | add stencil buffer
-`no_clear` | not cleared between draws (non-deterministic)
 
 ## valign choices
 

--- a/libnodegl/features.h
+++ b/libnodegl/features.h
@@ -54,6 +54,7 @@
 #define NGLI_FEATURE_UINT_UNIFORMS                (1 << 29)
 #define NGLI_FEATURE_EGL_ANDROID_GET_IMAGE_NATIVE_CLIENT_BUFFER (1 << 30)
 #define NGLI_FEATURE_KHR_DEBUG                    (1ULL << 31)
+#define NGLI_FEATURE_CLEAR_BUFFER                 (1ULL << 32)
 
 #define NGLI_FEATURE_COMPUTE_SHADER_ALL (NGLI_FEATURE_COMPUTE_SHADER           | \
                                          NGLI_FEATURE_PROGRAM_INTERFACE_QUERY  | \

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -115,14 +115,19 @@ void ngli_gctx_transform_projection_matrix(struct gctx *s, float *dst)
     s->class->transform_projection_matrix(s, dst);
 }
 
+void ngli_gctx_begin_render_pass(struct gctx *s, struct rendertarget *rt)
+{
+    s->class->begin_render_pass(s, rt);
+}
+
+void ngli_gctx_end_render_pass(struct gctx *s)
+{
+    s->class->end_render_pass(s);
+}
+
 void ngli_gctx_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst)
 {
     s->class->get_rendertarget_uvcoord_matrix(s, dst);
-}
-
-void ngli_gctx_set_rendertarget(struct gctx *s, struct rendertarget *rt)
-{
-    s->class->set_rendertarget(s, rt);
 }
 
 struct rendertarget *ngli_gctx_get_rendertarget(struct gctx *s)

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -155,26 +155,6 @@ void ngli_gctx_get_scissor(struct gctx *s, int *scissor)
     s->class->get_scissor(s, scissor);
 }
 
-void ngli_gctx_set_clear_color(struct gctx *s, const float *color)
-{
-    s->class->set_clear_color(s, color);
-}
-
-void ngli_gctx_get_clear_color(struct gctx *s, float *color)
-{
-    s->class->get_clear_color(s, color);
-}
-
-void ngli_gctx_clear_color(struct gctx *s)
-{
-    s->class->clear_color(s);
-}
-
-void ngli_gctx_clear_depth_stencil(struct gctx *s)
-{
-    s->class->clear_depth_stencil(s);
-}
-
 int ngli_gctx_get_preferred_depth_format(struct gctx *s)
 {
     return s->class->get_preferred_depth_format(s);

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -175,11 +175,6 @@ void ngli_gctx_clear_depth_stencil(struct gctx *s)
     s->class->clear_depth_stencil(s);
 }
 
-void ngli_gctx_invalidate_depth_stencil(struct gctx *s)
-{
-    s->class->invalidate_depth_stencil(s);
-}
-
 int ngli_gctx_get_preferred_depth_format(struct gctx *s)
 {
     return s->class->get_preferred_depth_format(s);

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -75,7 +75,7 @@ int ngli_gctx_draw(struct gctx *s, struct ngl_node *scene, double t)
 
     if (scene) {
         struct ngl_ctx *ctx = scene->ctx;
-        struct rendertarget *rt = ngli_gctx_get_rendertarget(s);
+        struct rendertarget *rt = ngli_gctx_get_default_rendertarget(s);
         ctx->available_rendertargets[0] = rt;
         ctx->available_rendertargets[1] = rt;
         ctx->current_rendertarget = rt;
@@ -130,9 +130,9 @@ void ngli_gctx_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst)
     s->class->get_rendertarget_uvcoord_matrix(s, dst);
 }
 
-struct rendertarget *ngli_gctx_get_rendertarget(struct gctx *s)
+struct rendertarget *ngli_gctx_get_default_rendertarget(struct gctx *s)
 {
-    return s->class->get_rendertarget(s);
+    return s->class->get_default_rendertarget(s);
 }
 
 const struct rendertarget_desc *ngli_gctx_get_default_rendertarget_desc(struct gctx *s)

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -75,9 +75,11 @@ int ngli_gctx_draw(struct gctx *s, struct ngl_node *scene, double t)
 
     if (scene) {
         struct ngl_ctx *ctx = scene->ctx;
-        ctx->current_rendertarget = ngli_gctx_get_rendertarget(s);
+        struct rendertarget *rt = ngli_gctx_get_rendertarget(s);
+        ctx->available_rendertargets[0] = rt;
+        ctx->available_rendertargets[1] = rt;
+        ctx->current_rendertarget = rt;
         ctx->bind_current_rendertarget = 0;
-        ctx->clear_current_rendertarget = 0;
         LOG(DEBUG, "draw scene %s @ t=%f", scene->label, t);
         ngli_node_draw(scene);
     }

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -79,7 +79,7 @@ int ngli_gctx_draw(struct gctx *s, struct ngl_node *scene, double t)
         ctx->available_rendertargets[0] = rt;
         ctx->available_rendertargets[1] = rt;
         ctx->current_rendertarget = rt;
-        ctx->bind_current_rendertarget = 0;
+        ctx->begin_render_pass = 0;
         LOG(DEBUG, "draw scene %s @ t=%f", scene->label, t);
         ngli_node_draw(scene);
     }

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -52,10 +52,6 @@ struct gctx_class {
     void (*get_viewport)(struct gctx *s, int *viewport);
     void (*set_scissor)(struct gctx *s, const int *scissor);
     void (*get_scissor)(struct gctx *s, int *scissor);
-    void (*set_clear_color)(struct gctx *s, const float *color);
-    void (*get_clear_color)(struct gctx *s, float *color);
-    void (*clear_color)(struct gctx *s);
-    void (*clear_depth_stencil)(struct gctx *s);
     int (*get_preferred_depth_format)(struct gctx *s);
     int (*get_preferred_depth_stencil_format)(struct gctx *s);
 
@@ -126,12 +122,6 @@ void ngli_gctx_set_viewport(struct gctx *s, const int *viewport);
 void ngli_gctx_get_viewport(struct gctx *s, int *viewport);
 void ngli_gctx_set_scissor(struct gctx *s, const int *scissor);
 void ngli_gctx_get_scissor(struct gctx *s, int *scissor);
-
-void ngli_gctx_set_clear_color(struct gctx *s, const float *color);
-void ngli_gctx_get_clear_color(struct gctx *s, float *color);
-
-void ngli_gctx_clear_color(struct gctx *s);
-void ngli_gctx_clear_depth_stencil(struct gctx *s);
 
 int ngli_gctx_get_preferred_depth_format(struct gctx *s);
 int ngli_gctx_get_preferred_depth_stencil_format(struct gctx *s);

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -45,9 +45,12 @@ struct gctx_class {
     void (*transform_projection_matrix)(struct gctx *s, float *dst);
     void (*get_rendertarget_uvcoord_matrix)(struct gctx *s, float *dst);
 
-    void (*set_rendertarget)(struct gctx *s, struct rendertarget *rt);
     struct rendertarget *(*get_rendertarget)(struct gctx *s);
     const struct rendertarget_desc *(*get_default_rendertarget_desc)(struct gctx *s);
+
+    void (*begin_render_pass)(struct gctx *s, struct rendertarget *rt);
+    void (*end_render_pass)(struct gctx *s);
+
     void (*set_viewport)(struct gctx *s, const int *viewport);
     void (*get_viewport)(struct gctx *s, int *viewport);
     void (*set_scissor)(struct gctx *s, const int *scissor);
@@ -114,9 +117,11 @@ int ngli_gctx_transform_cull_mode(struct gctx *s, int cull_mode);
 void ngli_gctx_transform_projection_matrix(struct gctx *s, float *dst);
 void ngli_gctx_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst);
 
-void ngli_gctx_set_rendertarget(struct gctx *s, struct rendertarget *rt);
 struct rendertarget *ngli_gctx_get_rendertarget(struct gctx *s);
 const struct rendertarget_desc *ngli_gctx_get_default_rendertarget_desc(struct gctx *s);
+
+void ngli_gctx_begin_render_pass(struct gctx *s, struct rendertarget *rt);
+void ngli_gctx_end_render_pass(struct gctx *s);
 
 void ngli_gctx_set_viewport(struct gctx *s, const int *viewport);
 void ngli_gctx_get_viewport(struct gctx *s, int *viewport);

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -56,7 +56,6 @@ struct gctx_class {
     void (*get_clear_color)(struct gctx *s, float *color);
     void (*clear_color)(struct gctx *s);
     void (*clear_depth_stencil)(struct gctx *s);
-    void (*invalidate_depth_stencil)(struct gctx *s);
     int (*get_preferred_depth_format)(struct gctx *s);
     int (*get_preferred_depth_stencil_format)(struct gctx *s);
 
@@ -133,7 +132,6 @@ void ngli_gctx_get_clear_color(struct gctx *s, float *color);
 
 void ngli_gctx_clear_color(struct gctx *s);
 void ngli_gctx_clear_depth_stencil(struct gctx *s);
-void ngli_gctx_invalidate_depth_stencil(struct gctx *s);
 
 int ngli_gctx_get_preferred_depth_format(struct gctx *s);
 int ngli_gctx_get_preferred_depth_stencil_format(struct gctx *s);

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -45,7 +45,7 @@ struct gctx_class {
     void (*transform_projection_matrix)(struct gctx *s, float *dst);
     void (*get_rendertarget_uvcoord_matrix)(struct gctx *s, float *dst);
 
-    struct rendertarget *(*get_rendertarget)(struct gctx *s);
+    struct rendertarget *(*get_default_rendertarget)(struct gctx *s);
     const struct rendertarget_desc *(*get_default_rendertarget_desc)(struct gctx *s);
 
     void (*begin_render_pass)(struct gctx *s, struct rendertarget *rt);
@@ -117,7 +117,7 @@ int ngli_gctx_transform_cull_mode(struct gctx *s, int cull_mode);
 void ngli_gctx_transform_projection_matrix(struct gctx *s, float *dst);
 void ngli_gctx_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst);
 
-struct rendertarget *ngli_gctx_get_rendertarget(struct gctx *s);
+struct rendertarget *ngli_gctx_get_default_rendertarget(struct gctx *s);
 const struct rendertarget_desc *ngli_gctx_get_default_rendertarget_desc(struct gctx *s);
 
 void ngli_gctx_begin_render_pass(struct gctx *s, struct rendertarget *rt);

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -296,8 +296,6 @@ static int gl_init(struct gctx *s)
     const GLint scissor[] = {0, 0, gl->width, gl->height};
     ngli_gctx_set_scissor(s, scissor);
 
-    ngli_gctx_set_clear_color(s, config->clear_color);
-
     return 0;
 }
 
@@ -472,50 +470,6 @@ static void gl_get_scissor(struct gctx *s, int *scissor)
     memcpy(scissor, &s_priv->scissor, sizeof(s_priv->scissor));
 }
 
-static void gl_set_clear_color(struct gctx *s, const float *color)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    struct glcontext *gl = s_priv->glcontext;
-    memcpy(s_priv->clear_color, color, sizeof(s_priv->clear_color));
-    ngli_glClearColor(gl, color[0], color[1], color[2], color[3]);
-}
-
-static void gl_get_clear_color(struct gctx *s, float *color)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    memcpy(color, &s_priv->clear_color, sizeof(s_priv->clear_color));
-}
-
-static void gl_clear_color(struct gctx *s)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    struct glcontext *gl = s_priv->glcontext;
-    struct glstate *glstate = &s_priv->glstate;
-
-    const int scissor_test = glstate->scissor_test;
-    ngli_glDisable(gl, GL_SCISSOR_TEST);
-
-    ngli_glClear(gl, GL_COLOR_BUFFER_BIT);
-
-    if (scissor_test)
-        ngli_glEnable(gl, GL_SCISSOR_TEST);
-}
-
-static void gl_clear_depth_stencil(struct gctx *s)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    struct glcontext *gl = s_priv->glcontext;
-    struct glstate *glstate = &s_priv->glstate;
-
-    const int scissor_test = glstate->scissor_test;
-    ngli_glDisable(gl, GL_SCISSOR_TEST);
-
-    ngli_glClear(gl, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-
-    if (scissor_test)
-        ngli_glEnable(gl, GL_SCISSOR_TEST);
-}
-
 static int gl_get_preferred_depth_format(struct gctx *s)
 {
     return NGLI_FORMAT_D16_UNORM;
@@ -546,10 +500,6 @@ const struct gctx_class ngli_gctx_gl = {
     .get_viewport             = gl_get_viewport,
     .set_scissor              = gl_set_scissor,
     .get_scissor              = gl_get_scissor,
-    .set_clear_color          = gl_set_clear_color,
-    .get_clear_color          = gl_get_clear_color,
-    .clear_color              = gl_clear_color,
-    .clear_depth_stencil      = gl_clear_depth_stencil,
     .get_preferred_depth_format = gl_get_preferred_depth_format,
     .get_preferred_depth_stencil_format = gl_get_preferred_depth_stencil_format,
 
@@ -614,10 +564,6 @@ const struct gctx_class ngli_gctx_gles = {
     .get_viewport             = gl_get_viewport,
     .set_scissor              = gl_set_scissor,
     .get_scissor              = gl_get_scissor,
-    .set_clear_color          = gl_set_clear_color,
-    .get_clear_color          = gl_get_clear_color,
-    .clear_color              = gl_clear_color,
-    .clear_depth_stencil      = gl_clear_depth_stencil,
     .get_preferred_depth_format = gl_get_preferred_depth_format,
     .get_preferred_depth_stencil_format = gl_get_preferred_depth_stencil_format,
 

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -406,7 +406,7 @@ static void gl_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst)
     memcpy(dst, matrix, 4 * 4 * sizeof(float));
 }
 
-static struct rendertarget *gl_get_rendertarget(struct gctx *s)
+static struct rendertarget *gl_get_default_rendertarget(struct gctx *s)
 {
     struct gctx_gl *s_priv = (struct gctx_gl *)s;
     const struct ngl_config *config = &s->config;
@@ -502,7 +502,7 @@ const struct gctx_class ngli_gctx_gl = {
     .transform_projection_matrix      = gl_transform_projection_matrix,
     .get_rendertarget_uvcoord_matrix  = gl_get_rendertarget_uvcoord_matrix,
 
-    .get_rendertarget         = gl_get_rendertarget,
+    .get_default_rendertarget      = gl_get_default_rendertarget,
     .get_default_rendertarget_desc = gl_get_default_rendertarget_desc,
 
     .begin_render_pass        = gl_begin_render_pass,
@@ -569,7 +569,7 @@ const struct gctx_class ngli_gctx_gles = {
     .transform_projection_matrix      = gl_transform_projection_matrix,
     .get_rendertarget_uvcoord_matrix  = gl_get_rendertarget_uvcoord_matrix,
 
-    .get_rendertarget         = gl_get_rendertarget,
+    .get_default_rendertarget      = gl_get_default_rendertarget,
     .get_default_rendertarget_desc = gl_get_default_rendertarget_desc,
 
     .begin_render_pass        = gl_begin_render_pass,

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -49,7 +49,6 @@ static void capture_default(struct gctx *s)
     struct ngl_config *config = &s->config;
     struct rendertarget *rt = s_priv->rt;
 
-    ngli_rendertarget_resolve(rt);
     if (config->capture_buffer)
         ngli_rendertarget_read_pixels(rt, config->capture_buffer);
 }
@@ -58,9 +57,7 @@ static void capture_ios(struct gctx *s)
 {
     struct gctx_gl *s_priv = (struct gctx_gl *)s;
     struct glcontext *gl = s_priv->glcontext;
-    struct rendertarget *rt = s_priv->rt;
 
-    ngli_rendertarget_resolve(rt);
     ngli_glFinish(gl);
 }
 
@@ -193,7 +190,6 @@ static int offscreen_rendertarget_init(struct gctx *s)
 
     s_priv->capture_func = ios_capture ? capture_ios : capture_default;
 
-    ngli_gctx_set_rendertarget(s, s_priv->rt);
     const int vp[4] = {0, 0, config->width, config->height};
     ngli_gctx_set_viewport(s, vp);
 
@@ -328,6 +324,9 @@ static int gl_pre_draw(struct gctx *s, double t)
     struct gctx_gl *s_priv = (struct gctx_gl *)s;
     struct glcontext *gl = s_priv->glcontext;
     const struct ngl_config *config = &s->config;
+
+    ngli_gctx_begin_render_pass(s, config->offscreen ? s_priv->rt : NULL);
+
     const float *color = config->clear_color;
     ngli_glClearColor(gl, color[0], color[1], color[2], color[3]);
     ngli_glClear(gl, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
@@ -341,6 +340,8 @@ static int gl_post_draw(struct gctx *s, double t)
     struct ngl_config *config = &s->config;
 
     ngli_glstate_update(s, &s_priv->default_graphicstate);
+
+    ngli_gctx_end_render_pass(s);
 
     if (s_priv->capture_func)
         s_priv->capture_func(s);
@@ -405,17 +406,25 @@ static void gl_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst)
     memcpy(dst, matrix, 4 * 4 * sizeof(float));
 }
 
-static void gl_set_rendertarget(struct gctx *s, struct rendertarget *rt)
+static struct rendertarget *gl_get_rendertarget(struct gctx *s)
+{
+    struct gctx_gl *s_priv = (struct gctx_gl *)s;
+    const struct ngl_config *config = &s->config;
+    if (config->offscreen)
+        return s_priv->rt;
+    return NULL;
+}
+
+static const struct rendertarget_desc *gl_get_default_rendertarget_desc(struct gctx *s)
+{
+    struct gctx_gl *s_priv = (struct gctx_gl *)s;
+    return &s_priv->default_rendertarget_desc;
+}
+
+static void gl_begin_render_pass(struct gctx *s, struct rendertarget *rt)
 {
     struct gctx_gl *s_priv = (struct gctx_gl *)s;
     struct glcontext *gl = s_priv->glcontext;
-
-    if (rt == s_priv->rendertarget)
-        return;
-
-    if (s_priv->rendertarget) {
-        ngli_rendertarget_gl_invalidate(s_priv->rendertarget);
-    }
 
     struct rendertarget_gl *rt_gl = (struct rendertarget_gl *)rt;
     const GLuint fbo_id = rt_gl ? rt_gl->id : ngli_glcontext_get_default_framebuffer(gl);
@@ -432,16 +441,16 @@ static void gl_set_rendertarget(struct gctx *s, struct rendertarget *rt)
     s_priv->rendertarget = rt;
 }
 
-static struct rendertarget *gl_get_rendertarget(struct gctx *s)
+static void gl_end_render_pass(struct gctx *s)
 {
     struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    return s_priv->rendertarget;
-}
 
-static const struct rendertarget_desc *gl_get_default_rendertarget_desc(struct gctx *s)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    return &s_priv->default_rendertarget_desc;
+    if (s_priv->rendertarget) {
+        ngli_rendertarget_gl_resolve(s_priv->rendertarget);
+        ngli_rendertarget_gl_invalidate(s_priv->rendertarget);
+    }
+
+    s_priv->rendertarget = NULL;
 }
 
 static void gl_set_viewport(struct gctx *s, const int *viewport)
@@ -493,9 +502,12 @@ const struct gctx_class ngli_gctx_gl = {
     .transform_projection_matrix      = gl_transform_projection_matrix,
     .get_rendertarget_uvcoord_matrix  = gl_get_rendertarget_uvcoord_matrix,
 
-    .set_rendertarget         = gl_set_rendertarget,
     .get_rendertarget         = gl_get_rendertarget,
     .get_default_rendertarget_desc = gl_get_default_rendertarget_desc,
+
+    .begin_render_pass        = gl_begin_render_pass,
+    .end_render_pass          = gl_end_render_pass,
+
     .set_viewport             = gl_set_viewport,
     .get_viewport             = gl_get_viewport,
     .set_scissor              = gl_set_scissor,
@@ -557,9 +569,12 @@ const struct gctx_class ngli_gctx_gles = {
     .transform_projection_matrix      = gl_transform_projection_matrix,
     .get_rendertarget_uvcoord_matrix  = gl_get_rendertarget_uvcoord_matrix,
 
-    .set_rendertarget         = gl_set_rendertarget,
     .get_rendertarget         = gl_get_rendertarget,
     .get_default_rendertarget_desc = gl_get_default_rendertarget_desc,
+
+    .begin_render_pass        = gl_begin_render_pass,
+    .end_render_pass          = gl_end_render_pass,
+
     .set_viewport             = gl_set_viewport,
     .get_viewport             = gl_get_viewport,
     .set_scissor              = gl_set_scissor,

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -516,18 +516,6 @@ static void gl_clear_depth_stencil(struct gctx *s)
         ngli_glEnable(gl, GL_SCISSOR_TEST);
 }
 
-static void gl_invalidate_depth_stencil(struct gctx *s)
-{
-    struct gctx_gl *s_priv = (struct gctx_gl *)s;
-    struct glcontext *gl = s_priv->glcontext;
-
-    if (!(gl->features & NGLI_FEATURE_INVALIDATE_SUBDATA))
-        return;
-
-    static const GLenum attachments[] = {GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
-    ngli_glInvalidateFramebuffer(gl, GL_FRAMEBUFFER, NGLI_ARRAY_NB(attachments), attachments);
-}
-
 static int gl_get_preferred_depth_format(struct gctx *s)
 {
     return NGLI_FORMAT_D16_UNORM;
@@ -562,7 +550,6 @@ const struct gctx_class ngli_gctx_gl = {
     .get_clear_color          = gl_get_clear_color,
     .clear_color              = gl_clear_color,
     .clear_depth_stencil      = gl_clear_depth_stencil,
-    .invalidate_depth_stencil = gl_invalidate_depth_stencil,
     .get_preferred_depth_format = gl_get_preferred_depth_format,
     .get_preferred_depth_stencil_format = gl_get_preferred_depth_stencil_format,
 
@@ -631,7 +618,6 @@ const struct gctx_class ngli_gctx_gles = {
     .get_clear_color          = gl_get_clear_color,
     .clear_color              = gl_clear_color,
     .clear_depth_stencil      = gl_clear_depth_stencil,
-    .invalidate_depth_stencil = gl_invalidate_depth_stencil,
     .get_preferred_depth_format = gl_get_preferred_depth_format,
     .get_preferred_depth_stencil_format = gl_get_preferred_depth_stencil_format,
 

--- a/libnodegl/gctx_gl.h
+++ b/libnodegl/gctx_gl.h
@@ -44,9 +44,9 @@ struct gctx_gl {
     struct gctx parent;
     struct glcontext *glcontext;
     struct glstate glstate;
-    struct rendertarget *rendertarget;
     struct graphicstate default_graphicstate;
     struct rendertarget_desc default_rendertarget_desc;
+    struct rendertarget *rendertarget;
     int viewport[4];
     int scissor[4];
     float clear_color[4];

--- a/libnodegl/gctx_gl.h
+++ b/libnodegl/gctx_gl.h
@@ -49,7 +49,6 @@ struct gctx_gl {
     struct rendertarget *rendertarget;
     int viewport[4];
     int scissor[4];
-    float clear_color[4];
     int timer_active;
     /* Offscreen render target */
     struct rendertarget *rt;

--- a/libnodegl/gen-gl-wrappers.py
+++ b/libnodegl/gen-gl-wrappers.py
@@ -107,6 +107,10 @@ cmds_optional = [
     'glDrawBuffer',
     'glDrawBuffers',
 
+    # Clear Buffer
+    'glClearBufferfv',
+    'glClearBufferfi',
+
     # UInt uniforms
     'glUniform1uiv',
     'glUniform2uiv',

--- a/libnodegl/gldefinitions_data.h
+++ b/libnodegl/gldefinitions_data.h
@@ -36,6 +36,8 @@ static const struct gldefinition {
     {"glBufferSubData", offsetof(struct glfunctions, BufferSubData), M},
     {"glCheckFramebufferStatus", offsetof(struct glfunctions, CheckFramebufferStatus), M},
     {"glClear", offsetof(struct glfunctions, Clear), M},
+    {"glClearBufferfi", offsetof(struct glfunctions, ClearBufferfi), 0},
+    {"glClearBufferfv", offsetof(struct glfunctions, ClearBufferfv), 0},
     {"glClearColor", offsetof(struct glfunctions, ClearColor), M},
     {"glClientWaitSync", offsetof(struct glfunctions, ClientWaitSync), 0},
     {"glColorMask", offsetof(struct glfunctions, ColorMask), M},

--- a/libnodegl/glfeatures_data.h
+++ b/libnodegl/glfeatures_data.h
@@ -258,5 +258,13 @@ static const struct glfeature {
         .es_version     = 320,
         .funcs_offsets  = (const size_t[]){OFFSET(DebugMessageCallback),
                                         -1}
+    }, {
+        .name           = "clear_buffer",
+        .flag           = NGLI_FEATURE_CLEAR_BUFFER,
+        .version        = 300,
+        .es_version     = 300,
+        .funcs_offsets  = (const size_t[]){OFFSET(ClearBufferfv),
+                                           OFFSET(ClearBufferfi),
+                                           -1}
     }
 };

--- a/libnodegl/glfeatures_data.h
+++ b/libnodegl/glfeatures_data.h
@@ -252,11 +252,11 @@ static const struct glfeature {
                                            OFFSET(Uniform4uiv),
                                            -1}
     }, {
-    .name           = "khr_debug",
-    .flag           = NGLI_FEATURE_KHR_DEBUG,
-    .version        = 430,
-    .es_version     = 320,
-    .funcs_offsets  = (const size_t[]){OFFSET(DebugMessageCallback),
-                                       -1}
+        .name           = "khr_debug",
+        .flag           = NGLI_FEATURE_KHR_DEBUG,
+        .version        = 430,
+        .es_version     = 320,
+        .funcs_offsets  = (const size_t[]){OFFSET(DebugMessageCallback),
+                                        -1}
     }
 };

--- a/libnodegl/glfunctions.h
+++ b/libnodegl/glfunctions.h
@@ -29,6 +29,8 @@ struct glfunctions {
     NGLI_GL_APIENTRY void (*BufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data);
     NGLI_GL_APIENTRY GLenum (*CheckFramebufferStatus)(GLenum target);
     NGLI_GL_APIENTRY void (*Clear)(GLbitfield mask);
+    NGLI_GL_APIENTRY void (*ClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+    NGLI_GL_APIENTRY void (*ClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value);
     NGLI_GL_APIENTRY void (*ClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
     NGLI_GL_APIENTRY GLenum (*ClientWaitSync)(GLsync sync, GLbitfield flags, GLuint64 timeout);
     NGLI_GL_APIENTRY void (*ColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
@@ -116,7 +118,7 @@ struct glfunctions {
     NGLI_GL_APIENTRY void (*RenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
     NGLI_GL_APIENTRY void (*RenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
     NGLI_GL_APIENTRY void (*Scissor)(GLint x, GLint y, GLsizei width, GLsizei height);
-    NGLI_GL_APIENTRY void (*ShaderBinary)(GLsizei count, const GLuint * shaders, GLenum binaryformat, const void * binary, GLsizei length);
+    NGLI_GL_APIENTRY void (*ShaderBinary)(GLsizei count, const GLuint * shaders, GLenum binaryFormat, const void * binary, GLsizei length);
     NGLI_GL_APIENTRY void (*ShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length);
     NGLI_GL_APIENTRY void (*StencilFunc)(GLenum func, GLint ref, GLuint mask);
     NGLI_GL_APIENTRY void (*StencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask);

--- a/libnodegl/glwrappers.h
+++ b/libnodegl/glwrappers.h
@@ -147,6 +147,18 @@ static inline void ngli_glClear(const struct glcontext *gl, GLbitfield mask)
     check_error_code(gl, "glClear");
 }
 
+static inline void ngli_glClearBufferfi(const struct glcontext *gl, GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)
+{
+    gl->funcs.ClearBufferfi(buffer, drawbuffer, depth, stencil);
+    check_error_code(gl, "glClearBufferfi");
+}
+
+static inline void ngli_glClearBufferfv(const struct glcontext *gl, GLenum buffer, GLint drawbuffer, const GLfloat * value)
+{
+    gl->funcs.ClearBufferfv(buffer, drawbuffer, value);
+    check_error_code(gl, "glClearBufferfv");
+}
+
 static inline void ngli_glClearColor(const struct glcontext *gl, GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
 {
     gl->funcs.ClearColor(red, green, blue, alpha);
@@ -679,9 +691,9 @@ static inline void ngli_glScissor(const struct glcontext *gl, GLint x, GLint y, 
     check_error_code(gl, "glScissor");
 }
 
-static inline void ngli_glShaderBinary(const struct glcontext *gl, GLsizei count, const GLuint * shaders, GLenum binaryformat, const void * binary, GLsizei length)
+static inline void ngli_glShaderBinary(const struct glcontext *gl, GLsizei count, const GLuint * shaders, GLenum binaryFormat, const void * binary, GLsizei length)
 {
-    gl->funcs.ShaderBinary(count, shaders, binaryformat, binary, length);
+    gl->funcs.ShaderBinary(count, shaders, binaryFormat, binary, length);
     check_error_code(gl, "glShaderBinary");
 }
 

--- a/libnodegl/hwconv.c
+++ b/libnodegl/hwconv.c
@@ -77,6 +77,8 @@ int ngli_hwconv_init(struct hwconv *hwconv, struct ngl_ctx *ctx,
         .nb_colors = 1,
         .colors[0] = {
             .attachment = texture,
+            .load_op    = NGLI_LOAD_OP_CLEAR,
+            .store_op   = NGLI_STORE_OP_STORE,
         }
     };
     hwconv->rt = ngli_rendertarget_create(gctx);
@@ -179,8 +181,6 @@ int ngli_hwconv_convert_image(struct hwconv *hwconv, const struct image *image)
 
     const int vp[4] = {0, 0, rt->width, rt->height};
     ngli_gctx_set_viewport(gctx, vp);
-
-    ngli_gctx_clear_color(gctx);
 
     struct pipeline *pipeline = hwconv->pipeline;
 

--- a/libnodegl/hwconv.c
+++ b/libnodegl/hwconv.c
@@ -173,8 +173,7 @@ int ngli_hwconv_convert_image(struct hwconv *hwconv, const struct image *image)
     ngli_assert(hwconv->src_params.layout == image->params.layout);
 
     struct rendertarget *rt = hwconv->rt;
-    struct rendertarget *prev_rt = ngli_gctx_get_rendertarget(gctx);
-    ngli_gctx_set_rendertarget(gctx, rt);
+    ngli_gctx_begin_render_pass(gctx, rt);
 
     int prev_vp[4] = {0};
     ngli_gctx_get_viewport(gctx, prev_vp);
@@ -217,7 +216,7 @@ int ngli_hwconv_convert_image(struct hwconv *hwconv, const struct image *image)
 
     ngli_pipeline_draw(hwconv->pipeline, 4, 1);
 
-    ngli_gctx_set_rendertarget(gctx, prev_rt);
+    ngli_gctx_end_render_pass(gctx);
     ngli_gctx_set_viewport(gctx, prev_vp);
 
     return 0;

--- a/libnodegl/node_hud.c
+++ b/libnodegl/node_hud.c
@@ -1412,12 +1412,7 @@ static void hud_draw(struct ngl_node *node)
     if (ctx->bind_current_rendertarget) {
         struct gctx *gctx = ctx->gctx;
         ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
-        if (ctx->clear_current_rendertarget) {
-            ngli_gctx_clear_color(gctx);
-            ngli_gctx_clear_depth_stencil(gctx);
-        }
         ctx->bind_current_rendertarget = 0;
-        ctx->clear_current_rendertarget = 0;
     }
 
     const float *modelview_matrix  = ngli_darray_tail(&ctx->modelview_matrix_stack);

--- a/libnodegl/node_hud.c
+++ b/libnodegl/node_hud.c
@@ -1409,6 +1409,17 @@ static void hud_draw(struct ngl_node *node)
     if (ret < 0)
         return;
 
+    if (ctx->bind_current_rendertarget) {
+        struct gctx *gctx = ctx->gctx;
+        ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+        if (ctx->clear_current_rendertarget) {
+            ngli_gctx_clear_color(gctx);
+            ngli_gctx_clear_depth_stencil(gctx);
+        }
+        ctx->bind_current_rendertarget = 0;
+        ctx->clear_current_rendertarget = 0;
+    }
+
     const float *modelview_matrix  = ngli_darray_tail(&ctx->modelview_matrix_stack);
     const float *projection_matrix = ngli_darray_tail(&ctx->projection_matrix_stack);
     ngli_pipeline_update_uniform(s->pipeline, s->modelview_matrix_index, modelview_matrix);

--- a/libnodegl/node_hud.c
+++ b/libnodegl/node_hud.c
@@ -1411,7 +1411,7 @@ static void hud_draw(struct ngl_node *node)
 
     if (ctx->bind_current_rendertarget) {
         struct gctx *gctx = ctx->gctx;
-        ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+        ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
         ctx->bind_current_rendertarget = 0;
     }
 

--- a/libnodegl/node_hud.c
+++ b/libnodegl/node_hud.c
@@ -1409,10 +1409,10 @@ static void hud_draw(struct ngl_node *node)
     if (ret < 0)
         return;
 
-    if (ctx->bind_current_rendertarget) {
+    if (ctx->begin_render_pass) {
         struct gctx *gctx = ctx->gctx;
         ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
-        ctx->bind_current_rendertarget = 0;
+        ctx->begin_render_pass = 0;
     }
 
     const float *modelview_matrix  = ngli_darray_tail(&ctx->modelview_matrix_stack);

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -55,14 +55,12 @@ struct rtt_priv {
 
 #define FEATURE_DEPTH       (1 << 0)
 #define FEATURE_STENCIL     (1 << 1)
-#define FEATURE_NO_CLEAR    (1 << 2)
 
 static const struct param_choices feature_choices = {
     .name = "framebuffer_features",
     .consts = {
         {"depth",   FEATURE_DEPTH,   .desc=NGLI_DOCSTRING("add depth buffer")},
         {"stencil", FEATURE_STENCIL, .desc=NGLI_DOCSTRING("add stencil buffer")},
-        {"no_clear",FEATURE_NO_CLEAR,.desc=NGLI_DOCSTRING("not cleared between draws (non-deterministic)")},
         {NULL}
     }
 };
@@ -314,9 +312,7 @@ static int rtt_prefetch(struct ngl_node *node)
             if (ret < 0)
                 return ret;
             rt_params.depth_stencil.attachment = depth;
-
-            if (!(s->features & FEATURE_NO_CLEAR))
-                s->invalidate_depth_stencil = 1;
+            s->invalidate_depth_stencil = 1;
         }
     }
 
@@ -389,7 +385,7 @@ static void rtt_draw(struct ngl_node *node)
 
     ctx->current_rendertarget = s->rt;
     ctx->bind_current_rendertarget = 1;
-    ctx->clear_current_rendertarget = !(s->features & FEATURE_NO_CLEAR);
+    ctx->clear_current_rendertarget = 1;
 
     ngli_node_draw(s->child);
 

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -414,6 +414,10 @@ static void rtt_draw(struct ngl_node *node)
         ctx->available_rendertargets[1],
     };
 
+    if (!ctx->bind_current_rendertarget) {
+        ngli_gctx_end_render_pass(gctx);
+    }
+
     ctx->available_rendertargets[0] = s->available_rendertargets[0];
     ctx->available_rendertargets[1] = s->available_rendertargets[1];
     ctx->current_rendertarget = s->available_rendertargets[0];
@@ -422,12 +426,10 @@ static void rtt_draw(struct ngl_node *node)
     ngli_node_draw(s->child);
 
     if (ctx->bind_current_rendertarget) {
-        ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+        ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
         ctx->bind_current_rendertarget = 0;
     }
-
-    if (s->samples > 0)
-        ngli_rendertarget_resolve(ctx->current_rendertarget);
+    ngli_gctx_end_render_pass(gctx);
 
     ctx->current_rendertarget = prev_rendertargets[1];
     ctx->available_rendertargets[0] = prev_rendertargets[0];

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -414,27 +414,27 @@ static void rtt_draw(struct ngl_node *node)
         ctx->available_rendertargets[1],
     };
 
-    if (!ctx->bind_current_rendertarget) {
+    if (!ctx->begin_render_pass) {
         ngli_gctx_end_render_pass(gctx);
     }
 
     ctx->available_rendertargets[0] = s->available_rendertargets[0];
     ctx->available_rendertargets[1] = s->available_rendertargets[1];
     ctx->current_rendertarget = s->available_rendertargets[0];
-    ctx->bind_current_rendertarget = 1;
+    ctx->begin_render_pass = 1;
 
     ngli_node_draw(s->child);
 
-    if (ctx->bind_current_rendertarget) {
+    if (ctx->begin_render_pass) {
         ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
-        ctx->bind_current_rendertarget = 0;
+        ctx->begin_render_pass = 0;
     }
     ngli_gctx_end_render_pass(gctx);
 
     ctx->current_rendertarget = prev_rendertargets[1];
     ctx->available_rendertargets[0] = prev_rendertargets[0];
     ctx->available_rendertargets[1] = prev_rendertargets[1];
-    ctx->bind_current_rendertarget = 1;
+    ctx->begin_render_pass = 1;
 
     ngli_gctx_set_viewport(gctx, prev_vp);
 

--- a/libnodegl/node_text.c
+++ b/libnodegl/node_text.c
@@ -26,6 +26,7 @@
 #include "nodes.h"
 #include "darray.h"
 #include "drawutils.h"
+#include "gctx.h"
 #include "log.h"
 #include "math_utils.h"
 #include "pgcache.h"
@@ -669,6 +670,17 @@ static void text_draw(struct ngl_node *node)
 
     struct pipeline_desc *descs = ngli_darray_data(&s->pipeline_descs);
     struct pipeline_desc *desc = &descs[ctx->rnode_pos->id];
+
+    if (ctx->bind_current_rendertarget) {
+        struct gctx *gctx = ctx->gctx;
+        ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+        if (ctx->clear_current_rendertarget) {
+            ngli_gctx_clear_color(gctx);
+            ngli_gctx_clear_depth_stencil(gctx);
+        }
+        ctx->bind_current_rendertarget = 0;
+        ctx->clear_current_rendertarget = 0;
+    }
 
     struct pipeline_subdesc *bg_desc = &desc->bg;
     ngli_pipeline_update_uniform(bg_desc->pipeline, bg_desc->modelview_matrix_index, modelview_matrix);

--- a/libnodegl/node_text.c
+++ b/libnodegl/node_text.c
@@ -674,12 +674,7 @@ static void text_draw(struct ngl_node *node)
     if (ctx->bind_current_rendertarget) {
         struct gctx *gctx = ctx->gctx;
         ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
-        if (ctx->clear_current_rendertarget) {
-            ngli_gctx_clear_color(gctx);
-            ngli_gctx_clear_depth_stencil(gctx);
-        }
         ctx->bind_current_rendertarget = 0;
-        ctx->clear_current_rendertarget = 0;
     }
 
     struct pipeline_subdesc *bg_desc = &desc->bg;

--- a/libnodegl/node_text.c
+++ b/libnodegl/node_text.c
@@ -671,10 +671,10 @@ static void text_draw(struct ngl_node *node)
     struct pipeline_desc *descs = ngli_darray_data(&s->pipeline_descs);
     struct pipeline_desc *desc = &descs[ctx->rnode_pos->id];
 
-    if (ctx->bind_current_rendertarget) {
+    if (ctx->begin_render_pass) {
         struct gctx *gctx = ctx->gctx;
         ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
-        ctx->bind_current_rendertarget = 0;
+        ctx->begin_render_pass = 0;
     }
 
     struct pipeline_subdesc *bg_desc = &desc->bg;

--- a/libnodegl/node_text.c
+++ b/libnodegl/node_text.c
@@ -673,7 +673,7 @@ static void text_draw(struct ngl_node *node)
 
     if (ctx->bind_current_rendertarget) {
         struct gctx *gctx = ctx->gctx;
-        ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+        ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
         ctx->bind_current_rendertarget = 0;
     }
 

--- a/libnodegl/nodes.h
+++ b/libnodegl/nodes.h
@@ -83,9 +83,9 @@ struct ngl_ctx {
     struct rnode *rnode_pos;
     struct ngl_node *scene;
     struct ngl_config config;
+    struct rendertarget *available_rendertargets[2];
     struct rendertarget *current_rendertarget;
     int bind_current_rendertarget;
-    int clear_current_rendertarget;
     struct darray modelview_matrix_stack;
     struct darray projection_matrix_stack;
     struct darray activitycheck_nodes;

--- a/libnodegl/nodes.h
+++ b/libnodegl/nodes.h
@@ -85,7 +85,7 @@ struct ngl_ctx {
     struct ngl_config config;
     struct rendertarget *available_rendertargets[2];
     struct rendertarget *current_rendertarget;
-    int bind_current_rendertarget;
+    int begin_render_pass;
     struct darray modelview_matrix_stack;
     struct darray projection_matrix_stack;
     struct darray activitycheck_nodes;

--- a/libnodegl/pass.c
+++ b/libnodegl/pass.c
@@ -697,12 +697,7 @@ int ngli_pass_exec(struct pass *s)
         if (ctx->bind_current_rendertarget) {
             struct gctx *gctx = ctx->gctx;
             ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
-            if (ctx->clear_current_rendertarget) {
-                ngli_gctx_clear_color(gctx);
-                ngli_gctx_clear_depth_stencil(gctx);
-            }
             ctx->bind_current_rendertarget = 0;
-            ctx->clear_current_rendertarget = 0;
         }
 
         if (s->indices_buffer)

--- a/libnodegl/pass.c
+++ b/libnodegl/pass.c
@@ -696,7 +696,7 @@ int ngli_pass_exec(struct pass *s)
     if (s->pipeline_type == NGLI_PIPELINE_TYPE_GRAPHICS) {
         if (ctx->bind_current_rendertarget) {
             struct gctx *gctx = ctx->gctx;
-            ngli_gctx_set_rendertarget(gctx, ctx->current_rendertarget);
+            ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
             ctx->bind_current_rendertarget = 0;
         }
 
@@ -705,6 +705,13 @@ int ngli_pass_exec(struct pass *s)
         else
             ngli_pipeline_draw(pipeline, s->nb_vertices, s->nb_instances);
     } else {
+        if (!ctx->bind_current_rendertarget) {
+            struct gctx *gctx = ctx->gctx;
+            ngli_gctx_end_render_pass(gctx);
+            ctx->current_rendertarget = ctx->available_rendertargets[1];
+            ctx->bind_current_rendertarget = 1;
+        }
+
         ngli_pipeline_dispatch(pipeline, params->nb_group_x, params->nb_group_y, params->nb_group_z);
     }
 

--- a/libnodegl/pass.c
+++ b/libnodegl/pass.c
@@ -694,10 +694,10 @@ int ngli_pass_exec(struct pass *s)
     }
 
     if (s->pipeline_type == NGLI_PIPELINE_TYPE_GRAPHICS) {
-        if (ctx->bind_current_rendertarget) {
+        if (ctx->begin_render_pass) {
             struct gctx *gctx = ctx->gctx;
             ngli_gctx_begin_render_pass(gctx, ctx->current_rendertarget);
-            ctx->bind_current_rendertarget = 0;
+            ctx->begin_render_pass = 0;
         }
 
         if (s->indices_buffer)
@@ -705,11 +705,11 @@ int ngli_pass_exec(struct pass *s)
         else
             ngli_pipeline_draw(pipeline, s->nb_vertices, s->nb_instances);
     } else {
-        if (!ctx->bind_current_rendertarget) {
+        if (!ctx->begin_render_pass) {
             struct gctx *gctx = ctx->gctx;
             ngli_gctx_end_render_pass(gctx);
             ctx->current_rendertarget = ctx->available_rendertargets[1];
-            ctx->bind_current_rendertarget = 1;
+            ctx->begin_render_pass = 1;
         }
 
         ngli_pipeline_dispatch(pipeline, params->nb_group_x, params->nb_group_y, params->nb_group_z);

--- a/libnodegl/rendertarget.h
+++ b/libnodegl/rendertarget.h
@@ -27,6 +27,17 @@
 
 #define NGLI_MAX_COLOR_ATTACHMENTS 8
 
+enum {
+    NGLI_LOAD_OP_LOAD,
+    NGLI_LOAD_OP_CLEAR,
+    NGLI_LOAD_OP_DONT_CARE,
+};
+
+enum {
+    NGLI_STORE_OP_STORE,
+    NGLI_STORE_OP_DONT_CARE,
+};
+
 struct attachment_desc {
     int format;
     int samples;
@@ -44,6 +55,9 @@ struct attachment {
     int attachment_layer;
     struct texture *resolve_target;
     int resolve_target_layer;
+    int load_op;
+    float clear_value[4];
+    int store_op;
 };
 
 struct rendertarget_params {

--- a/libnodegl/rendertarget_gl.h
+++ b/libnodegl/rendertarget_gl.h
@@ -32,12 +32,19 @@ struct rendertarget_gl {
     GLuint prev_id;
     GLenum draw_buffers[NGLI_MAX_COLOR_ATTACHMENTS];
     GLenum blit_draw_buffers[NGLI_MAX_COLOR_ATTACHMENTS*(NGLI_MAX_COLOR_ATTACHMENTS+1)/2];
+    GLenum clear_flags;
+    GLenum invalidate_attachments[NGLI_MAX_COLOR_ATTACHMENTS + 2]; // max color attachments + depth and stencil attachments
+    int nb_invalidate_attachments;
+    void (*clear)(struct rendertarget *s);
+    void (*invalidate)(struct rendertarget *s);
     void (*resolve)(struct rendertarget *s);
 };
 
 struct rendertarget *ngli_rendertarget_gl_create(struct gctx *gctx);
 int ngli_rendertarget_gl_init(struct rendertarget *s, const struct rendertarget_params *params);
 void ngli_rendertarget_gl_resolve(struct rendertarget *s);
+void ngli_rendertarget_gl_clear(struct rendertarget *s);
+void ngli_rendertarget_gl_invalidate(struct rendertarget *s);
 void ngli_rendertarget_gl_read_pixels(struct rendertarget *s, uint8_t *data);
 void ngli_rendertarget_gl_freep(struct rendertarget **sp);
 

--- a/ngl-tools/player.c
+++ b/ngl-tools/player.c
@@ -348,16 +348,18 @@ static struct ngl_node *add_progress_bar(struct ngl_node *scene)
     struct ngl_node *v_duration = ngl_node_create(NGL_NODE_UNIFORMFLOAT);
     struct ngl_node *v_opacity  = ngl_node_create(NGL_NODE_UNIFORMFLOAT);
     struct ngl_node *coord      = ngl_node_create(NGL_NODE_IOVEC2);
-    struct ngl_node *group      = ngl_node_create(NGL_NODE_GROUP);
+    struct ngl_node *ui_group   = ngl_node_create(NGL_NODE_GROUP);
     struct ngl_node *gcfg       = ngl_node_create(NGL_NODE_GRAPHICCONFIG);
+    struct ngl_node *group      = ngl_node_create(NGL_NODE_GROUP);
 
     if (!text || !quad || !program || !render || !time || !v_duration || !v_opacity ||
         !coord || !group || !gcfg) {
-        ngl_node_unrefp(&gcfg);
+        ngl_node_unrefp(&group);
         goto end;
     }
 
-    struct ngl_node *children[] = {scene, render, text};
+    struct ngl_node *ui_children[] = {render, text};
+    struct ngl_node *children[] = {scene, gcfg};
 
     ngl_node_param_set(quad, "corner", bar_corner);
     ngl_node_param_set(quad, "width",  bar_width);
@@ -376,14 +378,16 @@ static struct ngl_node *add_progress_bar(struct ngl_node *scene)
     ngl_node_param_set(render, "frag_resources", "duration", v_duration);
     ngl_node_param_set(render, "frag_resources", "opacity",  v_opacity);
 
-    ngl_node_param_add(group, "children", ARRAY_NB(children), children);
+    ngl_node_param_add(ui_group, "children", ARRAY_NB(ui_children), ui_children);
 
-    ngl_node_param_set(gcfg, "child", group);
+    ngl_node_param_set(gcfg, "child", ui_group);
     ngl_node_param_set(gcfg, "blend", 1);
     ngl_node_param_set(gcfg, "blend_src_factor",   "src_alpha");
     ngl_node_param_set(gcfg, "blend_dst_factor",   "one_minus_src_alpha");
     ngl_node_param_set(gcfg, "blend_src_factor_a", "zero");
     ngl_node_param_set(gcfg, "blend_dst_factor_a", "one");
+
+    ngl_node_param_add(group, "children", ARRAY_NB(children), children);
 
     ngl_node_param_set(text, "box_corner", text_corner);
     ngl_node_param_set(text, "box_width", text_width);
@@ -404,9 +408,9 @@ end:
     ngl_node_unrefp(&v_duration);
     ngl_node_unrefp(&v_opacity);
     ngl_node_unrefp(&coord);
-    ngl_node_unrefp(&group);
+    ngl_node_unrefp(&gcfg);
 
-    return gcfg;
+    return group;
 }
 
 static int set_scene(struct ngl_node *scene)

--- a/tests/rtt.py
+++ b/tests/rtt.py
@@ -139,7 +139,8 @@ def _get_rtt_scene(cfg, features='depth', texture_ds_format=None, samples=0, mip
         [texture],
         features=features,
         depth_texture=texture_depth,
-        samples=samples
+        samples=samples,
+        clear_color=(0, 0, 0, 1),
     )
 
     quad = ngl.Quad((-1, -1, 0), (2, 0, 0), (0, 2, 0))

--- a/tests/texture.py
+++ b/tests/texture.py
@@ -204,7 +204,7 @@ def texture_scissor(cfg):
     render.update_frag_resources(color=color)
     graphic_config = ngl.GraphicConfig(render, scissor_test=True, scissor=(32, 32, 32, 32))
     texture = ngl.Texture2D(width=64, height=64)
-    rtt = ngl.RenderToTexture(graphic_config, [texture])
+    rtt = ngl.RenderToTexture(graphic_config, [texture], clear_color=(0, 0, 0, 1))
 
     program = ngl.Program(vertex=cfg.get_vert('texture'), fragment=cfg.get_frag('texture'))
     program.update_vert_out_vars(var_tex0_coord=ngl.IOVec2(), var_uvcoord=ngl.IOVec2())


### PR DESCRIPTION
Also moves from ngli_gctx_set_rendertarget() to ngli_gctx_{begin,end}_render_pass().