### PR TITLE
rendertarget: remove ngli_rendertarget_resolve()

### DIFF
--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -88,7 +88,6 @@ struct gctx_class {
 
     struct rendertarget *(*rendertarget_create)(struct gctx *ctx);
     int (*rendertarget_init)(struct rendertarget *s, const struct rendertarget_params *params);
-    void (*rendertarget_resolve)(struct rendertarget *s);
     void (*rendertarget_read_pixels)(struct rendertarget *s, uint8_t *data);
     void (*rendertarget_freep)(struct rendertarget **sp);
 

--- a/libnodegl/gctx_gl.c
+++ b/libnodegl/gctx_gl.c
@@ -545,7 +545,6 @@ const struct gctx_class ngli_gctx_gl = {
 
     .rendertarget_create      = ngli_rendertarget_gl_create,
     .rendertarget_init        = ngli_rendertarget_gl_init,
-    .rendertarget_resolve     = ngli_rendertarget_gl_resolve,
     .rendertarget_read_pixels = ngli_rendertarget_gl_read_pixels,
     .rendertarget_freep       = ngli_rendertarget_gl_freep,
 
@@ -614,7 +613,6 @@ const struct gctx_class ngli_gctx_gles = {
 
     .rendertarget_create      = ngli_rendertarget_gl_create,
     .rendertarget_init        = ngli_rendertarget_gl_init,
-    .rendertarget_resolve     = ngli_rendertarget_gl_resolve,
     .rendertarget_read_pixels = ngli_rendertarget_gl_read_pixels,
     .rendertarget_freep       = ngli_rendertarget_gl_freep,
 

--- a/libnodegl/rendertarget.c
+++ b/libnodegl/rendertarget.c
@@ -32,11 +32,6 @@ int ngli_rendertarget_init(struct rendertarget *s, const struct rendertarget_par
     return s->gctx->class->rendertarget_init(s, params);
 }
 
-void ngli_rendertarget_resolve(struct rendertarget *s)
-{
-    s->gctx->class->rendertarget_resolve(s);
-}
-
 void ngli_rendertarget_read_pixels(struct rendertarget *s, uint8_t *data)
 {
     s->gctx->class->rendertarget_read_pixels(s, data);


### PR DESCRIPTION
Forgotten in a7fc90b9cf75412b815889d0a2964e6c8112405a.