### PR TITLE
rtt: remove vflip parameter

### DIFF
--- a/libnodegl/doc/libnodegl.md
+++ b/libnodegl/doc/libnodegl.md
@@ -457,7 +457,6 @@ Parameter | Live-chg. | Type | Description | Default
 `samples` |  | [`int`](#parameter-types) | number of samples used for multisampling anti-aliasing | `0`
 `clear_color` |  | [`vec4`](#parameter-types) | color used to clear the `color_texture` | (`0`,`0`,`0`,`0`)
 `features` |  | [`framebuffer_features`](#framebuffer_features-choices) | framebuffer feature mask | `0`
-`vflip` |  | [`bool`](#parameter-types) | apply a vertical flip to `color_texture` and `depth_texture` transformation matrices to match the `node.gl` uv coordinates system | `1`
 
 
 **Source**: [node_rtt.c](/libnodegl/node_rtt.c)

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -39,7 +39,6 @@ struct rtt_priv {
     int samples;
     float clear_color[4];
     int features;
-    int vflip;
 
     int use_rt_resume;
     int width;
@@ -86,8 +85,6 @@ static const struct node_param rtt_params[] = {
     {"features",      PARAM_TYPE_FLAGS, OFFSET(features),
                       .choices=&feature_choices,
                       .desc=NGLI_DOCSTRING("framebuffer feature mask")},
-    {"vflip",         PARAM_TYPE_BOOL, OFFSET(vflip), {.i64=1},
-                      .desc=NGLI_DOCSTRING("apply a vertical flip to `color_texture` and `depth_texture` transformation matrices to match the `node.gl` uv coordinates system")},
     {NULL}
 };
 
@@ -356,20 +353,18 @@ static int rtt_prefetch(struct ngl_node *node)
         s->available_rendertargets[1] = s->rt_resume;
     }
 
-    if (s->vflip) {
-        /* flip vertically the color and depth textures so the coordinates
-         * match how the uv coordinates system works */
-        for (int i = 0; i < s->nb_color_textures; i++) {
-            struct texture_priv *texture_priv = s->color_textures[i]->priv_data;
-            struct image *image = &texture_priv->image;
-            ngli_gctx_get_rendertarget_uvcoord_matrix(gctx, image->coordinates_matrix);
-        }
+    /* transform the color and depth textures so the coordinates
+     * match how the graphics context uv coordinate system works */
+    for (int i = 0; i < s->nb_color_textures; i++) {
+        struct texture_priv *texture_priv = s->color_textures[i]->priv_data;
+        struct image *image = &texture_priv->image;
+        ngli_gctx_get_rendertarget_uvcoord_matrix(gctx, image->coordinates_matrix);
+    }
 
-        if (s->depth_texture) {
-            struct texture_priv *depth_texture_priv = s->depth_texture->priv_data;
-            struct image *depth_image = &depth_texture_priv->image;
-            ngli_gctx_get_rendertarget_uvcoord_matrix(gctx, depth_image->coordinates_matrix);
-        }
+    if (s->depth_texture) {
+        struct texture_priv *depth_texture_priv = s->depth_texture->priv_data;
+        struct image *depth_image = &depth_texture_priv->image;
+        ngli_gctx_get_rendertarget_uvcoord_matrix(gctx, depth_image->coordinates_matrix);
     }
 
     return 0;

--- a/libnodegl/nodes.specs
+++ b/libnodegl/nodes.specs
@@ -302,7 +302,6 @@
     - [samples, int]
     - [clear_color, vec4]
     - [features, flags]
-    - [vflip, bool]
 
 - ResourceProps:
     - [precision, select]


### PR DESCRIPTION
This parameter was useful for users relying on the OpenGL backend and
prepared the geometry and uv coordinates to deal with the rendertarget
output being vertically flipped.

Since df18098f01ff9795018b23dfc844225f325db527, we alter the
rendertarget output coordinate matrix for OpenGL offscreen rendering.

Moreover, this parameter won't work as expected with other graphics API.