### PR TITLE
rendertarget_gl: do not try to delete the default framebuffer

### DIFF
--- a/libnodegl/rendertarget_gl.h
+++ b/libnodegl/rendertarget_gl.h
@@ -27,6 +27,7 @@
 
 struct rendertarget_gl {
     struct rendertarget parent;
+    int wrapped;
     GLuint id;
     GLuint resolve_id;
     GLenum draw_buffers[NGLI_MAX_COLOR_ATTACHMENTS];


### PR DESCRIPTION
While this won't be an issue with the OpenGL default framebuffer as the
framebuffer value is 0 (glDeleteFramebuffers() silently ignores 0), it
is an issue on the EAGL platform as the default framebuffer is a
framebuffer object managed by glcontext_eagl.m.

Forgotten in 0f799469b069a5d6b90724ae6cb96c02bdb1dc41.