### PR TITLE
ci: Add Github action workflow ci_win.yml file

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,0 +1,30 @@
+name: 'tests Windows'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  build_libs:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64 # Start a 64 bit Mingw environment
+          update: true
+
+      - name: Install dependencies
+        run: |
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git make"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg,python}"
+
+      - name: Build
+        run: |
+          $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
+          C:\msys64\usr\bin\bash -lc "make -j$(($(nproc)+1)) TARGET_OS=MinGW-w64"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and API can change at any time.
 
 ![tests Linux](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Linux/badge.svg)
 ![tests Mac](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Mac/badge.svg)
+![tests Windows](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Windows/badge.svg)
 [![coverage](https://codecov.io/gh/gopro/gopro-lib-node.gl/branch/master/graph/badge.svg)](https://codecov.io/gh/gopro/gopro-lib-node.gl)
 
 [gopro]: https://gopro.com/


### PR DESCRIPTION
- This PR introduces the CI file for build on Windows (here windows-latest but can be fixed to windows-2019).
- I tested the file on my forked repo, see [build](https://github.com/mrobertseidowsky-gpsw/gopro-lib-node.gl/runs/1298599290?check_suite_focus=true)
- Installation of dependencies takes around 10min and the build takes around 1min.
- The env variable CHERE_INVOKING is necessary to stay in the same repository, if not, the Makefile is not found.
- Don't forget to update your README with a new badge !