### PR TITLE
tools/desktop: simplify macOS SDL issue workaround

### DIFF
--- a/ngl-tools/ngl-desktop.c
+++ b/ngl-tools/ngl-desktop.c
@@ -20,14 +20,14 @@
  */
 
 /*
- * To workaround a SDL issue¹ on macOS, we need to include <string.h> before
- * defining _POSIX_C_SOURCE to ensure that memset_pattern4() is defined. This
+ * To workaround a SDL issue¹ on macOS, we need to define _DARWIN_C_SOURCE when
+ * _POSIX_C_SOURCE is also set to ensure that memset_pattern4() is defined. This
  * is mandatory because SDL_stdinc.h (included by SDL.h) uses memset_pattern4()
  * unconditionally on Apple systems.
  * [1]: https://bugzilla.libsdl.org/show_bug.cgi?id=5107
  */
 #ifdef __APPLE__
-#include <string.h>
+#define _DARWIN_C_SOURCE
 #endif
 
 #define _POSIX_C_SOURCE 200112L // for struct addrinfo with glibc


### PR DESCRIPTION
This uses the same pattern used in SDL upstream to address the issue.