### PR TITLE
pynodegl: add TEST_OPTIONS=dump to dump tests outputs to the filesystem

### DIFF
--- a/pynodegl-utils/pynodegl_utils/tests/cmp.py
+++ b/pynodegl-utils/pynodegl_utils/tests/cmp.py
@@ -21,9 +21,11 @@
 #
 
 import os
+import os.path as op
 import difflib
 import pynodegl as ngl
 from pynodegl_utils.misc import get_backend
+import tempfile
 
 
 class CompareBase:
@@ -36,7 +38,7 @@ class CompareBase:
     def deserialize(data):
         return data
 
-    def get_out_data(self):
+    def get_out_data(self, debug=False, debug_func=None):
         raise NotImplementedError
 
     def compare_data(self, test_name, ref_data, out_data):
@@ -50,6 +52,13 @@ class CompareBase:
             diff = ''.join(difflib.unified_diff(ref_data, out_data, fromfile=test_name + '-ref', tofile=test_name + '-out', n=10))
             err.append('{} fail:\n{}'.format(test_name, diff))
         return err
+
+    @staticmethod
+    def dump_image(img, dump_index, func_name=None):
+        filename = op.join(get_temp_dir(), f'{func_name}_{dump_index:03}.png')
+        print(f'Dumping output image to {filename}')
+        img.save(filename)
+        dump_index += 1
 
 
 class CompareSceneBase(CompareBase):
@@ -133,3 +142,10 @@ def get_test_decorator(cls):
             return user_func
         return test_decorator
     return test_func
+
+
+def get_temp_dir():
+    dir = op.join(tempfile.gettempdir(), 'nodegl/tests')
+    if not op.exists(dir):
+        os.makedirs(dir)
+    return dir

--- a/pynodegl-utils/pynodegl_utils/tests/cmp_cuepoints.py
+++ b/pynodegl-utils/pynodegl_utils/tests/cmp_cuepoints.py
@@ -20,7 +20,13 @@
 # under the License.
 #
 
-from .cmp import CompareSceneBase, get_test_decorator
+import os.path as op
+from PIL import Image
+
+from .cmp import CompareBase, CompareSceneBase, get_test_decorator, get_temp_dir
+
+_MODE = 'RGBA'
+
 
 class _CompareCuePoints(CompareSceneBase):
 
@@ -56,9 +62,14 @@ class _CompareCuePoints(CompareSceneBase):
         y = min(max(y, 0), height - 1)
         return [x, y]
 
-    def get_out_data(self):
+    def get_out_data(self, dump=False, func_name=None):
         cpoints = []
+        dump_index = 0
         for (width, height, capture_buffer) in self.render_frames():
+            if dump:
+                img = Image.frombuffer(_MODE, (width, height), capture_buffer, 'raw', _MODE, 0, 1)
+                CompareBase.dump_image(img, dump_index, func_name)
+                dump_index += 1
             frame_cpoints = {}
             for point_name, (x, y) in self._points.items():
                 pix_x, pix_y = self._pos_to_px((x, y), width, height)

--- a/pynodegl-utils/pynodegl_utils/tests/cmp_fingerprint.py
+++ b/pynodegl-utils/pynodegl_utils/tests/cmp_fingerprint.py
@@ -20,9 +20,10 @@
 # under the License.
 #
 
+import os.path as op
 from PIL import Image
 
-from .cmp import CompareSceneBase, get_test_decorator
+from .cmp import CompareBase, CompareSceneBase, get_test_decorator, get_temp_dir
 
 
 _HSIZE = 8
@@ -73,11 +74,14 @@ class _CompareFingerprints(CompareSceneBase):
             hashes.append(comp_hash)
         return hashes
 
-    def get_out_data(self):
+    def get_out_data(self, dump=False, func_name=None):
         hashes = []
+        dump_index = 0
         for (width, height, capture_buffer) in self.render_frames():
-            # TODO: png output for debug?
             img = Image.frombuffer(_MODE, (width, height), capture_buffer, 'raw', _MODE, 0, 1)
+            if dump:
+                CompareBase.dump_image(img, dump_index, func_name)
+                dump_index += 1
             img = img.resize((_HSIZE + 1, _HSIZE + 1), resample=Image.LANCZOS)
             data = img.tobytes()
             frame_hashes = self._get_plane_hashes(data)

--- a/pynodegl-utils/pynodegl_utils/tests/cmp_floats.py
+++ b/pynodegl-utils/pynodegl_utils/tests/cmp_floats.py
@@ -45,7 +45,7 @@ class _CompareFloats(CompareBase):
             ret.append([name] + [float(f) for f in floats.split()])
         return ret
 
-    def get_out_data(self):
+    def get_out_data(self, debug=False, debug_func=None):
         return self._func(**self._func_kwargs)
 
     def compare_data(self, test_name, ref_data, out_data):

--- a/pynodegl-utils/pynodegl_utils/tests/cmp_resources.py
+++ b/pynodegl-utils/pynodegl_utils/tests/cmp_resources.py
@@ -59,7 +59,7 @@ class _CompareResources(CompareSceneBase):
         os.close(fd)
         return ngl.HUD(scene, export_filename=self._csvfile)
 
-    def get_out_data(self):
+    def get_out_data(self, debug=False, debug_func=None):
         for frame in self.render_frames():
             pass
 


### PR DESCRIPTION
Signed-off-by: Matthieu Bouron <matthieu.bouron@gmail.com>

Here are the following changes from the original commit:
- misc cosmetics
- os.path import changed to import os.path as op
- removed unnecessary calls to os.path.normpath
- used os.path.join() to build image output filenames (instead of string concatenation)
- removed unnecessary prints
- removed unused debug parameter from _run_test()
- renamed debug, debug_func to dump, func_name
- renamed DEBUG option to TESTS_OPTIONS=dump
- added TESTS_OPTIONS description in usage message
- added dump and func_name parameters to all get_out_data() calls (so it still works when GEN is specified)







