### PR TITLE
utils/misc: use a try-except form in get_nodegl_tempdir()

### DIFF
--- a/pynodegl-utils/pynodegl_utils/misc.py
+++ b/pynodegl-utils/pynodegl_utils/misc.py
@@ -135,8 +135,10 @@ class Media:
 
 def get_nodegl_tempdir():
     tmpdir = op.join(tempfile.gettempdir(), 'nodegl')
-    if not op.exists(tmpdir):
+    try:
         os.makedirs(tmpdir)
+    except FileExistsError:
+        pass
     return tmpdir
 
 


### PR DESCRIPTION
os.makedirs() can be called in a race condition scenario, which
typically happens during the tests with parallel jobs. The try..except
makes this code resistant to such a scenario.