### PR TITLE
rendertarget_gl: fix depth stencil texture attachment on OpenGLES 2.0

### DIFF
--- a/libnodegl/api.c
+++ b/libnodegl/api.c
@@ -407,6 +407,7 @@ static const char *get_cap_string_id(unsigned cap_id)
     case NGL_CAP_MAX_COMPUTE_GROUP_SIZE_Z:      return "max_compute_group_size_z";
     case NGL_CAP_MAX_SAMPLES:                   return "max_samples";
     case NGL_CAP_NPOT_TEXTURE:                  return "npot_texture";
+    case NGL_CAP_SHADER_TEXTURE_LOD:            return "shader_texture_lod";
     case NGL_CAP_TEXTURE_3D:                    return "texture_3d";
     case NGL_CAP_TEXTURE_CUBE:                  return "texture_cube";
     }
@@ -423,6 +424,7 @@ static int load_caps(struct ngl_backend *backend, const struct gctx *gctx)
     const int has_compute        = ALL_FEATURES(gctx->features, NGLI_FEATURE_COMPUTE_SHADER_ALL);
     const int has_instanced_draw = ALL_FEATURES(gctx->features, NGLI_FEATURE_INSTANCED_ARRAY);
     const int has_npot_texture   = ALL_FEATURES(gctx->features, NGLI_FEATURE_TEXTURE_NPOT);
+    const int has_shader_texture_lod = ALL_FEATURES(gctx->features, NGLI_FEATURE_SHADER_TEXTURE_LOD);
     const int has_texture_3d     = ALL_FEATURES(gctx->features, NGLI_FEATURE_TEXTURE_3D);
     const int has_texture_cube   = ALL_FEATURES(gctx->features, NGLI_FEATURE_TEXTURE_CUBE_MAP);
 
@@ -440,6 +442,7 @@ static int load_caps(struct ngl_backend *backend, const struct gctx *gctx)
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_SIZE_Z,      limits->max_compute_work_group_sizes[2]),
         CAP(NGL_CAP_MAX_SAMPLES,                   limits->max_samples),
         CAP(NGL_CAP_NPOT_TEXTURE,                  has_npot_texture),
+        CAP(NGL_CAP_SHADER_TEXTURE_LOD,            has_shader_texture_lod),
         CAP(NGL_CAP_TEXTURE_3D,                    has_texture_3d),
         CAP(NGL_CAP_TEXTURE_CUBE,                  has_texture_cube),
     };

--- a/libnodegl/api.c
+++ b/libnodegl/api.c
@@ -430,6 +430,7 @@ static int load_caps(struct ngl_backend *backend, const struct gctx *gctx)
     const struct ngl_cap caps[] = {
         CAP(NGL_CAP_BLOCK,                         has_block),
         CAP(NGL_CAP_COMPUTE,                       has_compute),
+        CAP(NGL_CAP_INSTANCED_DRAW,                has_instanced_draw),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_X,     limits->max_compute_work_group_counts[0]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Y,     limits->max_compute_work_group_counts[1]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Z,     limits->max_compute_work_group_counts[2]),
@@ -437,7 +438,6 @@ static int load_caps(struct ngl_backend *backend, const struct gctx *gctx)
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_SIZE_X,      limits->max_compute_work_group_sizes[0]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_SIZE_Y,      limits->max_compute_work_group_sizes[1]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_SIZE_Z,      limits->max_compute_work_group_sizes[2]),
-        CAP(NGL_CAP_INSTANCED_DRAW,                has_instanced_draw),
         CAP(NGL_CAP_MAX_SAMPLES,                   limits->max_samples),
         CAP(NGL_CAP_NPOT_TEXTURE,                  has_npot_texture),
         CAP(NGL_CAP_TEXTURE_3D,                    has_texture_3d),

--- a/libnodegl/api.c
+++ b/libnodegl/api.c
@@ -398,6 +398,7 @@ static const char *get_cap_string_id(unsigned cap_id)
     case NGL_CAP_BLOCK:                         return "block";
     case NGL_CAP_COMPUTE:                       return "compute";
     case NGL_CAP_INSTANCED_DRAW:                return "instanced_draw";
+    case NGL_CAP_MAX_COLOR_ATTACHMENTS:         return "max_color_attachments";
     case NGL_CAP_MAX_COMPUTE_GROUP_COUNT_X:     return "max_compute_group_count_x";
     case NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Y:     return "max_compute_group_count_y";
     case NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Z:     return "max_compute_group_count_z";
@@ -433,6 +434,7 @@ static int load_caps(struct ngl_backend *backend, const struct gctx *gctx)
         CAP(NGL_CAP_BLOCK,                         has_block),
         CAP(NGL_CAP_COMPUTE,                       has_compute),
         CAP(NGL_CAP_INSTANCED_DRAW,                has_instanced_draw),
+        CAP(NGL_CAP_MAX_COLOR_ATTACHMENTS,         limits->max_color_attachments),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_X,     limits->max_compute_work_group_counts[0]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Y,     limits->max_compute_work_group_counts[1]),
         CAP(NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Z,     limits->max_compute_work_group_counts[2]),

--- a/libnodegl/backends/gl/glfeatures_data.h
+++ b/libnodegl/backends/gl/glfeatures_data.h
@@ -52,6 +52,7 @@ static const struct glfeature {
         .flag           = NGLI_FEATURE_TEXTURE_3D,
         .version        = 200,
         .es_version     = 300,
+        .es_extensions  = (const char*[]){"GL_OES_texture_3D", NULL},
         .funcs_offsets  = (const size_t[]){OFFSET(TexImage3D),
                                            OFFSET(TexSubImage3D),
                                            -1}

--- a/libnodegl/backends/gl/glfeatures_data.h
+++ b/libnodegl/backends/gl/glfeatures_data.h
@@ -21,6 +21,8 @@
 
 /* WARNING: this file must only be included once */
 
+#include <stddef.h>
+
 #include "glcontext.h"
 
 #define OFFSET(x) offsetof(struct glfunctions, x)

--- a/libnodegl/backends/gl/glfeatures_data.h
+++ b/libnodegl/backends/gl/glfeatures_data.h
@@ -280,5 +280,11 @@ static const struct glfeature {
         .flag           = NGLI_FEATURE_SHADING_LANGUAGE_420PACK,
         .version        = 420,
         .extensions     = (const char*[]){"GL_ARB_shading_language_420pack", NULL},
+    }, {
+        .name           = "shader_texture_lod",
+        .flag           = NGLI_FEATURE_SHADER_TEXTURE_LOD,
+        .version        = 300,
+        .es_version     = 300,
+        .es_extensions  = (const char*[]){"GL_EXT_shader_texture_lod", NULL},
     }
 };

--- a/libnodegl/backends/gl/rendertarget_gl.c
+++ b/libnodegl/backends/gl/rendertarget_gl.c
@@ -156,7 +156,12 @@ static int create_fbo(struct rendertarget *s, int resolve)
             }
             break;
         case GL_TEXTURE_2D:
-            ngli_glFramebufferTexture2D(gl, GL_FRAMEBUFFER, attachment_index, GL_TEXTURE_2D, texture_gl->id, 0);
+            if (gl->backend == NGL_BACKEND_OPENGLES && gl->version < 300 && attachment_index == GL_DEPTH_STENCIL_ATTACHMENT) {
+                ngli_glFramebufferTexture2D(gl, GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texture_gl->id, 0);
+                ngli_glFramebufferTexture2D(gl, GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, texture_gl->id, 0);
+            } else {
+                ngli_glFramebufferTexture2D(gl, GL_FRAMEBUFFER, attachment_index, GL_TEXTURE_2D, texture_gl->id, 0);
+            }
             break;
         default:
             ngli_assert(0);

--- a/libnodegl/feature.h
+++ b/libnodegl/feature.h
@@ -57,6 +57,7 @@
 #define NGLI_FEATURE_CLEAR_BUFFER                 (1ULL << 32)
 #define NGLI_FEATURE_SHADER_IMAGE_SIZE            (1ULL << 33)
 #define NGLI_FEATURE_SHADING_LANGUAGE_420PACK     (1ULL << 34)
+#define NGLI_FEATURE_SHADER_TEXTURE_LOD           (1ULL << 35)
 
 #define NGLI_FEATURE_COMPUTE_SHADER_ALL (NGLI_FEATURE_COMPUTE_SHADER           | \
                                          NGLI_FEATURE_PROGRAM_INTERFACE_QUERY  | \

--- a/libnodegl/nodegl.h.in
+++ b/libnodegl/nodegl.h.in
@@ -417,6 +417,7 @@ struct ngl_config {
 #define NGL_CAP_BLOCK                         NGL_NODE_BLOCK
 #define NGL_CAP_COMPUTE                       NGL_NODE_COMPUTE
 #define NGL_CAP_INSTANCED_DRAW                NGLI_FOURCC('I','D','r','w')
+#define NGL_CAP_MAX_COLOR_ATTACHMENTS         NGLI_FOURCC('M','C','A','t')
 #define NGL_CAP_MAX_COMPUTE_GROUP_COUNT_X     NGLI_FOURCC('C','G','c','x')
 #define NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Y     NGLI_FOURCC('C','G','c','y')
 #define NGL_CAP_MAX_COMPUTE_GROUP_COUNT_Z     NGLI_FOURCC('C','G','c','z')

--- a/libnodegl/nodegl.h.in
+++ b/libnodegl/nodegl.h.in
@@ -426,6 +426,7 @@ struct ngl_config {
 #define NGL_CAP_MAX_COMPUTE_GROUP_SIZE_Z      NGLI_FOURCC('C','G','s','z')
 #define NGL_CAP_MAX_SAMPLES                   NGLI_FOURCC('M','S','A','A')
 #define NGL_CAP_NPOT_TEXTURE                  NGLI_FOURCC('N','P','O','T')
+#define NGL_CAP_SHADER_TEXTURE_LOD            NGLI_FOURCC('S','T','L','d')
 #define NGL_CAP_TEXTURE_3D                    NGL_NODE_TEXTURE3D
 #define NGL_CAP_TEXTURE_CUBE                  NGL_NODE_TEXTURECUBE
 

--- a/libnodegl/pgcraft.c
+++ b/libnodegl/pgcraft.c
@@ -532,6 +532,7 @@ static void set_glsl_header(struct pgcraft *s, struct bstr *b, const struct pgcr
     const int require_image_external_essl3_feature = ngli_darray_count(&s->texture_infos) > 0 && s->glsl_version >= 300;
 #endif
     const int enable_shader_texture_lod = (gctx->features & NGLI_FEATURE_SHADER_TEXTURE_LOD) == NGLI_FEATURE_SHADER_TEXTURE_LOD;
+    const int enable_texture_3d         = (gctx->features & NGLI_FEATURE_TEXTURE_3D) == NGLI_FEATURE_TEXTURE_3D;
 
     const struct {
         int backend;
@@ -552,6 +553,7 @@ static void set_glsl_header(struct pgcraft *s, struct bstr *b, const struct pgcr
         {NGL_BACKEND_OPENGLES, "GL_OES_EGL_image_external_essl3", INT_MAX, require_image_external_essl3_feature},
 #endif
         {NGL_BACKEND_OPENGLES, "GL_EXT_shader_texture_lod",           300, enable_shader_texture_lod},
+        {NGL_BACKEND_OPENGLES, "GL_OES_texture_3D",                   300, enable_texture_3d},
     };
 
     for (int i = 0; i < NGLI_ARRAY_NB(features); i++) {

--- a/tests/texture.py
+++ b/tests/texture.py
@@ -278,7 +278,7 @@ void main()
 _RENDER_TEXTURE_LOD_FRAG = '''
 void main()
 {
-    ngl_out_color = textureLod(tex0, var_uvcoord, 0.5);
+    ngl_out_color = ngl_tex2dlod(tex0, var_uvcoord, 0.5);
 }
 '''
 

--- a/tests/texture.py
+++ b/tests/texture.py
@@ -31,12 +31,21 @@ from pynodegl_utils.toolbox.colors import COLORS
 from pynodegl_utils.toolbox.colors import get_random_color_buffer
 
 
+_RENDER_BUFFER_FRAG = '''
+void main()
+{
+    float color = ngl_tex2d(tex0, var_tex0_coord).r;
+    ngl_out_color = vec4(color, 0.0, 0.0, 1.0);
+}
+'''
+
+
 def _render_buffer(cfg, w, h):
     n = w * h
     data = array.array('B', [i * 255 // n for i in range(n)])
     buf = ngl.BufferUByte(data=data)
     texture = ngl.Texture2D(width=w, height=h, data_src=buf)
-    program = ngl.Program(vertex=cfg.get_vert('texture'), fragment=cfg.get_frag('texture'))
+    program = ngl.Program(vertex=cfg.get_vert('texture'), fragment=_RENDER_BUFFER_FRAG)
     program.update_vert_out_vars(var_tex0_coord=ngl.IOVec2(), var_uvcoord=ngl.IOVec2())
     render = ngl.Render(ngl.Quad(), program)
     render.update_frag_resources(tex0=texture)


### PR DESCRIPTION
GL_OES_packed_depth_stencil does not define a single combined attachment
point (GL_DEPTH_STENCIL_ATTACHMENT), thus, we need to attach the texture
to both GL_DEPTH_ATTACHMENT and GL_STENCIL_ATTACHMENT.