### PR TITLE
tools: use read/write instead of recv/send where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,10 +110,14 @@ pynodegl-utils-install: pynodegl-utils-deps-install
 # available on PyPi.
 #
 # We do not pull the requirements on Windows because of various issues:
-# - PySide2 can't be pulled
+# - PySide2 can't be pulled (required to be installed by the user outside the
+#   Python virtualenv)
 # - Pillow fails to find zlib (required to be installed by the user outside the
 #   Python virtualenv)
-# - ngl-control can not currently work because of temporary files handling
+# - ngl-control can not currently work because of:
+#     - temporary files handling
+#     - subprocess usage, passing fd is not supported on Windows
+#     - subprocess usage, Windows cannot execute directly hooks shell scripts
 #
 # Still, we want the module to be installed so we can access the scene()
 # decorator and other related utils.

--- a/doc/howto/installation.md
+++ b/doc/howto/installation.md
@@ -49,7 +49,9 @@ On Windows, the bootstrap is slightly more complex:
 pacman -Syuu  # and restart the shell
 pacman -S git make
 pacman -S mingw-w64-x86_64-{toolchain,ffmpeg,python}
+pacman -S mingw-w64-x86_64-python-watchdog
 pacman -S mingw-w64-x86_64-python3-{pillow,pip}
+pacman -S mingw-w64-x86_64-pyside2-qt5
 pacman -S mingw-w64-x86_64-meson
 make TARGET_OS=MinGW-w64
 ```

--- a/ngl-tools/ngl-desktop.c
+++ b/ngl-tools/ngl-desktop.c
@@ -41,6 +41,7 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <direct.h>
+#define SHUT_RDWR SD_BOTH
 #else
 #include <sys/socket.h>
 #include <sys/utsname.h>
@@ -628,19 +629,19 @@ end:
          * of behaviour is to prevent a possible race scenario where the same
          * FD would be re-used between a close() and an accept().
          *
-         * On Windows, both shutdown() and close() won't work, we have to use a
-         * Windows specific one: closesocket().
+         * On Windows, the specific closesocket() function must be used instead of
+         * close() to close a socket.
          *
          * See https://bugzilla.kernel.org/show_bug.cgi?id=106241 for more
          * information.
          */
+        if (shutdown(s.sock_fd, SHUT_RDWR) < 0)
+            perror("shutdown");
 #if _WIN32
         closesocket(s.sock_fd);
 #else
-        if (shutdown(s.sock_fd, SHUT_RDWR) < 0)
-            perror("shutdown");
-#endif
         close(s.sock_fd);
+#endif
     }
 
     if (s.addr_info)

--- a/ngl-tools/ngl-desktop.c
+++ b/ngl-tools/ngl-desktop.c
@@ -219,7 +219,7 @@ static int handle_tag_filepart(struct ctx *s, const uint8_t *data, int size)
         return ipc_pkt_add_rtag_fileend(s->send_pkt, s->upload_path);
     }
 
-    const ssize_t n = send(s->upload_fd, data, size, 0);
+    const ssize_t n = write(s->upload_fd, data, size);
     if (n < 0) {
         perror("write");
         close_upload_file(s);

--- a/ngl-tools/ngl-desktop.c
+++ b/ngl-tools/ngl-desktop.c
@@ -405,7 +405,7 @@ static void close_socket(int socket)
 
 static void close_conn(struct ctx *s, int conn_fd)
 {
-    close(conn_fd);
+    close_socket(conn_fd);
     fprintf(stderr, "<< client %d disconnected\n", conn_fd);
 
     /* close uploading file when the connection ends */

--- a/ngl-tools/ngl-ipc.c
+++ b/ngl-tools/ngl-ipc.c
@@ -42,6 +42,10 @@
 #include "ipc.h"
 #include "opts.h"
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 #define UPLOAD_CHUNK_SIZE (1024 * 1024)
 
 struct ctx {
@@ -110,7 +114,7 @@ static int craft_packet(struct ctx *s, struct ipc_pkt *pkt)
         const size_t name_size = name_len + 1;
 
         const char *filename = s->uploadfile + name_size;
-        s->upload_fd = open(filename, O_RDONLY);
+        s->upload_fd = open(filename, O_RDONLY | O_BINARY);
         if (s->upload_fd == -1) {
             perror("open");
             return NGL_ERROR_IO;

--- a/ngl-tools/ngl-ipc.c
+++ b/ngl-tools/ngl-ipc.c
@@ -251,7 +251,7 @@ static int handle_response(struct ctx *s, const struct ipc_pkt *pkt)
     if (s->upload_fd > 0) {
         ipc_pkt_reset(s->send_pkt);
 
-        const ssize_t n = recv(s->upload_fd, s->upload_buffer, UPLOAD_CHUNK_SIZE, 0);
+        const ssize_t n = read(s->upload_fd, s->upload_buffer, UPLOAD_CHUNK_SIZE);
         if (n < 0)
             return NGL_ERROR_IO;
         int ret = ipc_pkt_add_qtag_filepart(s->send_pkt, s->upload_buffer, n);


### PR DESCRIPTION
The recv and send functions must only be used on sockets (otherwise they
return ENOTSOCK).