### PR TITLE
WIP CI static/shared

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  linux:
+  linux-shared:
 
     runs-on: ubuntu-20.04
 
@@ -31,6 +31,26 @@ jobs:
     - name: Build
       run: |
         make -j$(($(nproc)+1))
+    - name: Run tests
+      run: |
+        DEBUG=yes DEBUG_GL=yes make -k -j$(($(nproc)+1)) tests
+
+  linux-static:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y update
+        sudo apt -y install libsdl2-dev python3-venv
+        sudo apt -y install ffmpeg libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
+
+    - name: Build
+      run: |
+        make -j$(($(nproc)+1)) SHARED=no
     - name: Run tests
       run: |
         DEBUG=yes DEBUG_GL=yes make -k -j$(($(nproc)+1)) tests

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  macos:
+  macos-shared:
 
     runs-on: macos-latest
 
@@ -24,3 +24,19 @@ jobs:
       run: |
         make -j$(($(sysctl -n hw.logicalcpu)+1))
 
+  macos-static:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: |
+        brew install python3 curl pkg-config sdl2 ffmpeg
+        # https://docs.brew.sh/Homebrew-and-Python
+        python3 -m pip install --upgrade pip
+
+    - name: Build
+      run: |
+        make -j$(($(sysctl -n hw.logicalcpu)+1)) SHARED=no

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  mingw:
+  mingw-shared:
 
     runs-on: windows-latest
 
@@ -30,3 +30,27 @@ jobs:
         run: |
           $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
           C:\msys64\usr\bin\bash -lc "make -j$(($(nproc)+1)) TARGET_OS=MinGW-w64"
+
+  mingw-static:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64 # Start a 64 bit Mingw environment
+          update: true
+
+      - name: Install dependencies
+        run: |
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git make"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg,python}"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-python3-{pillow,pip}"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-meson"
+
+      - name: Build
+        run: |
+          $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
+          C:\msys64\usr\bin\bash -lc "make -j$(($(nproc)+1)) TARGET_OS=MinGW-w64 SHARED=no"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ COVERAGE   ?= no
 PYTHON     ?= python$(if $(shell which python$(PYTHON_MAJOR) 2> /dev/null),$(PYTHON_MAJOR),)
 TARGET_OS  ?= $(shell uname -s)
 
+SHARED      ?= yes
 DEBUG_GL    ?= no
 DEBUG_MEM   ?= no
 DEBUG_SCENE ?= no
@@ -50,6 +51,9 @@ MESON_SETUP   = meson setup --prefix=$(PREFIX) --pkg-config-path=$(PREFIX)/lib/p
 # https://github.com/ninja-build/ninja/issues/1139#issuecomment-724061270
 MESON_COMPILE = MAKEFLAGS= meson compile
 MESON_INSTALL = meson install
+ifeq ($(SHARED),no)
+MESON_SETUP += --default-library static
+endif
 ifeq ($(COVERAGE),yes)
 MESON_SETUP += -Db_coverage=true
 DEBUG = yes


### PR DESCRIPTION
Hack to make build work:

```diff
diff --git a/ngl-tools/meson.build b/ngl-tools/meson.build
index 8292da9f..4976476e 100644
--- a/ngl-tools/meson.build
+++ b/ngl-tools/meson.build
@@ -43,7 +43,7 @@ add_project_arguments(
 #
 tool_deps = [
   cc.find_library('m', required: false),
-  dependency('libnodegl'),
+  dependency('libnodegl', static: true),
 ]
 sxplayer_dep = dependency('libsxplayer')  # for media probing
 threads_dep = dependency('threads', required: false)
```

See https://github.com/mesonbuild/meson/pull/6629 for a related discussion.

But:
1. it obviously requires to be automatic according to the lib build state
2. meson warns a lot (because many sub-dependencies aren't static)
3. Python binding is not functional at runtime (needs patching `pynodegl/setup.py`)