### PR TITLE
build: always export TARGET_OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PYTHON_MAJOR = 3
 DEBUG      ?= no
 COVERAGE   ?= no
 PYTHON     ?= python$(if $(shell which python$(PYTHON_MAJOR) 2> /dev/null),$(PYTHON_MAJOR),)
-TARGET_OS  ?= $(shell uname -s)
+export TARGET_OS ?= $(shell uname -s)
 
 DEBUG_GL    ?= no
 DEBUG_MEM   ?= no


### PR DESCRIPTION
TARGET_OS needs to be exported so it is always available in external
Makefiles.

Fixes TARGET_OS being uninitialized in external/Makefile when the root
Makefile is called without TARGET_OS specified.