### PR TITLE
utils: remove unnecessary Fileapi.h and Handleapi.h includes

### DIFF
--- a/libnodegl/utils.c
+++ b/libnodegl/utils.c
@@ -23,9 +23,10 @@
 #include <pthread.h>
 
 #ifdef _WIN32
-#include <Handleapi.h>
-#include <Fileapi.h>
+#define POW10_9 1000000000
+#include <Windows.h>
 #else
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -37,12 +38,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN32
-#define POW10_9 1000000000
-#include <Windows.h>
-#else
-#include <sys/time.h>
-#endif
 
 #include "log.h"
 #include "memory.h"


### PR DESCRIPTION
The Microsoft documentation suggests that Windows.h should be included
instead of Fileapi.h and/or Handleapi.h headers. Windows.h takes care of
including a bunch of core headers for the user (Fileapi.h, Handleapi.h,
Profileapi.h to name a few).

This resolves the following compile error on MSVC:
winnt.h(173,1): fatal error C1189: #error: "No Target Architecture".