### PR TITLE
internal: use __func__ instead of __FUNCTION__

### DIFF
--- a/libnodegl/backends/gl/gctx_gl.c
+++ b/libnodegl/backends/gl/gctx_gl.c
@@ -367,7 +367,7 @@ static struct gctx *gl_create(const struct ngl_config *config)
 }
 
 #if DEBUG_GL
-#define GL_DEBUG_LOG(log_level, ...) ngli_log_print(log_level, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define GL_DEBUG_LOG(log_level, ...) ngli_log_print(log_level, __FILE__, __LINE__, __func__, __VA_ARGS__)
 
 static void NGLI_GL_APIENTRY gl_debug_message_callback(GLenum source,
                                                        GLenum type,
@@ -618,7 +618,7 @@ static int gl_end_draw(struct gctx *s, double t)
         s_priv->capture_func(s);
 
     int ret = 0;
-    if (ngli_glcontext_check_gl_error(gl, __FUNCTION__))
+    if (ngli_glcontext_check_gl_error(gl, __func__))
         ret = -1;
 
     if (config->set_surface_pts)

--- a/libnodegl/log.h
+++ b/libnodegl/log.h
@@ -26,7 +26,7 @@
 #include "utils.h"
 
 #ifndef __PRETTY_FUNCTION__
-#define __PRETTY_FUNCTION__ __FUNCTION__
+#define __PRETTY_FUNCTION__ __func__
 #endif
 
 #define LOG(log_level, ...) ngli_log_print(NGL_LOG_##log_level, __FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__)

--- a/libnodegl/node_media.c
+++ b/libnodegl/node_media.c
@@ -98,7 +98,7 @@ static void callback_sxplayer_log(void *arg, int level, const char *filename, in
     char buf[512];
     vsnprintf(buf, sizeof(buf), fmt, vl);
     if (buf[0])
-        ngli_log_print(log_levels[level], __FILE__, __LINE__, __FUNCTION__,
+        ngli_log_print(log_levels[level], __FILE__, __LINE__, __func__,
                        "[SXPLAYER %s:%d %s] %s", filename, ln, fn, buf);
 }
 


### PR DESCRIPTION
__func__ is standardised and is part of C99 whereas __FUNCTION__ is not.

See https://tool.oschina.net/uploads/apidocs/gcc-4.7.1-manual/Function-Names.html.