### PR TITLE
pipeline: add stage information to textures and buffers

### DIFF
--- a/libnodegl/pgcraft.c
+++ b/libnodegl/pgcraft.c
@@ -319,6 +319,7 @@ static int inject_texture_info(struct pgcraft *s, struct pgcraft_texture_info *i
                 .location = -1,
                 .binding  = -1,
                 .access   = info->writable ? NGLI_ACCESS_READ_WRITE : NGLI_ACCESS_READ_BIT,
+                .stage    = stage,
             };
             snprintf(pl_texture_desc.name, sizeof(pl_texture_desc.name), "%s", field->name);
 
@@ -397,6 +398,7 @@ static int inject_block(struct pgcraft *s, struct bstr *b,
         .type    = named_block->type,
         .binding = -1,
         .access  = named_block->writable ? NGLI_ACCESS_READ_WRITE : NGLI_ACCESS_READ_BIT,
+        .stage   = stage,
     };
     int len = snprintf(pl_buffer_desc.name, sizeof(pl_buffer_desc.name), "%s_block", named_block->name);
     if (len >= sizeof(pl_buffer_desc.name)) {

--- a/libnodegl/pipeline.h
+++ b/libnodegl/pipeline.h
@@ -53,6 +53,7 @@ struct pipeline_texture_desc {
     int location;
     int binding;
     int access;
+    int stage;
 };
 
 struct pipeline_buffer_desc {
@@ -60,6 +61,7 @@ struct pipeline_buffer_desc {
     int type;
     int binding;
     int access;
+    int stage;
 };
 
 struct pipeline_attribute_desc {


### PR DESCRIPTION
This information will be useful for pipelines in modern backends during
binding.