### PR TITLE
Jbelaston/automatic vcvars64 detection

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -69,5 +69,4 @@ jobs:
       - name: Build
         run: |
           make -j$(($(nproc)+1)) TARGET_OS=Windows \
-          VCPKG_DIR='D:\\a\\gopro-lib-node.gl\\gopro-lib-node.gl\\vcpkg' \
-          VCVARS64='"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"'
+          VCPKG_DIR='D:\\a\\gopro-lib-node.gl\\gopro-lib-node.gl\\vcpkg'

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(info PREFIX_FULLPATH: $(PREFIX_FULLPATH))
 ifeq ($(TARGET_OS),Windows)
 # Initialize VCVARS64 and VCPKG_DIR to a default value
 # Note: the user should override this environment variable if needed
-VCVARS64 ?= "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+VCVARS64 ?= "$(shell powershell.exe .\\scripts\\find_vcvars64.ps1)"
 VCPKG_DIR ?= C:\\vcpkg
 PKG_CONF_DIR = external\\pkgconf\\build
 CMD = PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG="$(PREFIX_FULLPATH)\\Scripts\\pkg-config.exe" PKG_CONFIG_PATH="$(VCPKG_DIR)\\installed\\x64-windows\\lib\\pkgconfig" WSLENV=PKG_CONFIG/w:PKG_CONFIG_PATH/w:PKG_CONFIG_ALLOW_SYSTEM_LIBS/w:PKG_CONFIG_ALLOW_SYSTEM_CFLAGS/w cmd.exe /C

--- a/scripts/find_vcvars64.ps1
+++ b/scripts/find_vcvars64.ps1
@@ -1,0 +1,12 @@
+# Install VSSetup module if not existing
+if ((Get-InstalledModule -Name "VSSetup" -ErrorAction SilentlyContinue) -eq $null) {
+    Install-Module VSSetup -Scope CurrentUser -Force
+}
+
+# Get vcvars64 of latest VS installation instance
+$vsInstallationInfo = Get-VSSetupInstance -All -Prerelease |
+    Sort-Object -Property InstallationVersion -Descending |
+    Select-Object -First 1
+$vcvars64 = "$($vsInstallationInfo.InstallationPath)\VC\Auxiliary\Build\vcvars64.bat"
+
+Write-Host $vcvars64


### PR DESCRIPTION
Automatic detection and use of vcvars64.bat in the makefile.
This detection is done using Microsoft vswhere.exe utility (more info in the commit descriptions).

Note that I used a powershell script and not a batch (cmd) one since it is really friendly to use and especially is now the modern Windows approach. Would be good to progressively move all our current batches to powershell...