### PR TITLE
nodegl: rename class to cls

### DIFF
--- a/libnodegl/api.c
+++ b/libnodegl/api.c
@@ -494,7 +494,7 @@ static int backend_probe(struct ngl_backend *backend, const struct ngl_config *c
 
     backend->id         = config->backend;
     backend->string_id  = gctx->backend_str;
-    backend->name       = gctx->class->name;
+    backend->name       = gctx->cls->name;
 
     ret = load_caps(backend, gctx);
     if (ret < 0)

--- a/libnodegl/backends/gl/glcontext.c
+++ b/libnodegl/backends/gl/glcontext.c
@@ -392,10 +392,10 @@ struct glcontext *ngli_glcontext_new(const struct ngl_config *config)
     struct glcontext *glcontext = ngli_calloc(1, sizeof(*glcontext));
     if (!glcontext)
         return NULL;
-    glcontext->class = glcontext_class_map[glplatform];
+    glcontext->cls = glcontext_class_map[glplatform];
 
-    if (glcontext->class->priv_size) {
-        glcontext->priv_data = ngli_calloc(1, glcontext->class->priv_size);
+    if (glcontext->cls->priv_size) {
+        glcontext->priv_data = ngli_calloc(1, glcontext->cls->priv_size);
         if (!glcontext->priv_data) {
             ngli_free(glcontext);
             return NULL;
@@ -409,8 +409,8 @@ struct glcontext *ngli_glcontext_new(const struct ngl_config *config)
     glcontext->height = config->height;
     glcontext->samples = config->samples;
 
-    if (glcontext->class->init) {
-        int ret = glcontext->class->init(glcontext, config->display, config->window, config->handle);
+    if (glcontext->cls->init) {
+        int ret = glcontext->cls->init(glcontext, config->display, config->window, config->handle);
         if (ret < 0)
             goto fail;
     }
@@ -444,30 +444,30 @@ fail:
 
 int ngli_glcontext_make_current(struct glcontext *glcontext, int current)
 {
-    if (glcontext->class->make_current)
-        return glcontext->class->make_current(glcontext, current);
+    if (glcontext->cls->make_current)
+        return glcontext->cls->make_current(glcontext, current);
 
     return 0;
 }
 
 int ngli_glcontext_set_swap_interval(struct glcontext *glcontext, int interval)
 {
-    if (glcontext->class->set_swap_interval)
-        return glcontext->class->set_swap_interval(glcontext, interval);
+    if (glcontext->cls->set_swap_interval)
+        return glcontext->cls->set_swap_interval(glcontext, interval);
 
     return 0;
 }
 
 void ngli_glcontext_swap_buffers(struct glcontext *glcontext)
 {
-    if (glcontext->class->swap_buffers)
-        glcontext->class->swap_buffers(glcontext);
+    if (glcontext->cls->swap_buffers)
+        glcontext->cls->swap_buffers(glcontext);
 }
 
 void ngli_glcontext_set_surface_pts(struct glcontext *glcontext, double t)
 {
-    if (glcontext->class->set_surface_pts)
-        glcontext->class->set_surface_pts(glcontext, t);
+    if (glcontext->cls->set_surface_pts)
+        glcontext->cls->set_surface_pts(glcontext, t);
 }
 
 int ngli_glcontext_resize(struct glcontext *glcontext, int width, int height)
@@ -477,8 +477,8 @@ int ngli_glcontext_resize(struct glcontext *glcontext, int width, int height)
         return NGL_ERROR_INVALID_USAGE;
     }
 
-    if (glcontext->class->resize)
-        return glcontext->class->resize(glcontext, width, height);
+    if (glcontext->cls->resize)
+        return glcontext->cls->resize(glcontext, width, height);
 
     return NGL_ERROR_UNSUPPORTED;
 }
@@ -492,8 +492,8 @@ void ngli_glcontext_freep(struct glcontext **glcontextp)
 
     glcontext = *glcontextp;
 
-    if (glcontext->class->uninit)
-        glcontext->class->uninit(glcontext);
+    if (glcontext->cls->uninit)
+        glcontext->cls->uninit(glcontext);
 
     ngli_free(glcontext->priv_data);
     ngli_freep(glcontextp);
@@ -503,8 +503,8 @@ void *ngli_glcontext_get_proc_address(struct glcontext *glcontext, const char *n
 {
     void *ptr = NULL;
 
-    if (glcontext->class->get_proc_address)
-        ptr = glcontext->class->get_proc_address(glcontext, name);
+    if (glcontext->cls->get_proc_address)
+        ptr = glcontext->cls->get_proc_address(glcontext, name);
 
     return ptr;
 }
@@ -513,8 +513,8 @@ void *ngli_glcontext_get_texture_cache(struct glcontext *glcontext)
 {
     void *texture_cache = NULL;
 
-    if (glcontext->class->get_texture_cache)
-        texture_cache = glcontext->class->get_texture_cache(glcontext);
+    if (glcontext->cls->get_texture_cache)
+        texture_cache = glcontext->cls->get_texture_cache(glcontext);
 
     return texture_cache;
 }
@@ -523,8 +523,8 @@ uintptr_t ngli_glcontext_get_display(struct glcontext *glcontext)
 {
     uintptr_t handle = 0;
 
-    if (glcontext->class->get_display)
-        handle = glcontext->class->get_display(glcontext);
+    if (glcontext->cls->get_display)
+        handle = glcontext->cls->get_display(glcontext);
 
     return handle;
 }
@@ -533,8 +533,8 @@ uintptr_t ngli_glcontext_get_handle(struct glcontext *glcontext)
 {
     uintptr_t handle = 0;
 
-    if (glcontext->class->get_handle)
-        handle = glcontext->class->get_handle(glcontext);
+    if (glcontext->cls->get_handle)
+        handle = glcontext->cls->get_handle(glcontext);
 
     return handle;
 }
@@ -543,8 +543,8 @@ GLuint ngli_glcontext_get_default_framebuffer(struct glcontext *glcontext)
 {
     GLuint fbo_id = 0;
 
-    if (glcontext->class->get_default_framebuffer)
-        fbo_id = glcontext->class->get_default_framebuffer(glcontext);
+    if (glcontext->cls->get_default_framebuffer)
+        fbo_id = glcontext->cls->get_default_framebuffer(glcontext);
 
     return fbo_id;
 }

--- a/libnodegl/backends/gl/glcontext.h
+++ b/libnodegl/backends/gl/glcontext.h
@@ -33,7 +33,7 @@ struct glcontext_class;
 
 struct glcontext {
     /* GL context */
-    const struct glcontext_class *class;
+    const struct glcontext_class *cls;
     void *priv_data;
 
     /* User options */

--- a/libnodegl/buffer.c
+++ b/libnodegl/buffer.c
@@ -26,22 +26,22 @@
 
 struct buffer *ngli_buffer_create(struct gctx *gctx)
 {
-    return gctx->class->buffer_create(gctx);
+    return gctx->cls->buffer_create(gctx);
 }
 
 int ngli_buffer_init(struct buffer *s, int size, int usage)
 {
-    return s->gctx->class->buffer_init(s, size, usage);
+    return s->gctx->cls->buffer_init(s, size, usage);
 }
 
 int ngli_buffer_upload(struct buffer *s, const void *data, int size, int offset)
 {
-    return s->gctx->class->buffer_upload(s, data, size, offset);
+    return s->gctx->cls->buffer_upload(s, data, size, offset);
 }
 
 void ngli_buffer_freep(struct buffer **sp)
 {
     if (!*sp)
         return;
-    (*sp)->gctx->class->buffer_freep(sp);
+    (*sp)->gctx->cls->buffer_freep(sp);
 }

--- a/libnodegl/deserialize.c
+++ b/libnodegl/deserialize.c
@@ -435,7 +435,7 @@ static int set_node_params(struct darray *nodes_array, char *str,
                            const struct ngl_node *node)
 {
     uint8_t *base_ptr = node->priv_data;
-    const struct node_param *params = node->class->params;
+    const struct node_param *params = node->cls->params;
 
     if (!params)
         return 0;
@@ -449,7 +449,7 @@ static int set_node_params(struct darray *nodes_array, char *str,
         const struct node_param *par = ngli_node_param_find(node, str, &base_ptr);
         if (!par) {
             LOG(ERROR, "unable to find parameter %s.%s",
-                node->class->name, str);
+                node->cls->name, str);
             return NGL_ERROR_INVALID_DATA;
         }
 
@@ -457,7 +457,7 @@ static int set_node_params(struct darray *nodes_array, char *str,
         int ret = parse_param(nodes_array, base_ptr, par, str);
         if (ret < 0) {
             LOG(ERROR, "unable to set node param %s.%s: %s",
-                node->class->name, par->key, NGLI_RET_STR(ret));
+                node->cls->name, par->key, NGLI_RET_STR(ret));
             return ret;
         }
 

--- a/libnodegl/dot.c
+++ b/libnodegl/dot.c
@@ -110,7 +110,7 @@ static int should_print_par(uint8_t *priv, const struct node_param *par)
 
 static void print_custom_priv_options(struct bstr *b, const struct ngl_node *node)
 {
-    const struct node_param *par = node->class->params;
+    const struct node_param *par = node->cls->params;
     uint8_t *priv = node->priv_data;
 
     if (!par)
@@ -136,17 +136,17 @@ static void print_all_decls(struct bstr *b, const struct ngl_node *node, struct 
         return;
 
     ngli_bstr_printf(b, "    %s_%p[label=<<b>%s</b><br/>",
-                    node->class->name, node, node->class->name);
-    if (!ngli_is_default_label(node->class->name, node->label) && *node->label)
+                    node->cls->name, node, node->cls->name);
+    if (!ngli_is_default_label(node->cls->name, node->label) && *node->label)
         ngli_bstr_printf(b, "<i>%s</i><br/>", node->label);
     print_custom_priv_options(b, node);
     if (!node->ctx || node->is_active)
-        ngli_bstr_printf(b, ">,color="HSLFMT"]\n", get_hue(node->class->name));
+        ngli_bstr_printf(b, ">,color="HSLFMT"]\n", get_hue(node->cls->name));
     else
         ngli_bstr_print(b, ">,color="INACTIVE_COLOR"]\n");
 
     print_decls(b, node, ngli_base_node_params, (uint8_t *)node, decls);
-    print_decls(b, node, node->class->params, node->priv_data, decls);
+    print_decls(b, node, node->cls->params, node->priv_data, decls);
 }
 
 static void print_packed_decls(struct bstr *b, const char *label,
@@ -156,7 +156,7 @@ static void print_packed_decls(struct bstr *b, const char *label,
     ngli_bstr_printf(b, "    %s_%p[label=<<b>%s</b> (x%d)", label, children, label, nb_children);
     for (int i = 0; i < nb_children; i++) {
         const struct ngl_node *node = children[i];
-        char *info_str = node->class->info_str ? node->class->info_str(node) : NULL;
+        char *info_str = node->cls->info_str ? node->cls->info_str(node) : NULL;
         ngli_bstr_printf(b, LB "- %s", info_str ? info_str : "?");
         ngli_free(info_str);
     }
@@ -213,7 +213,7 @@ static void print_link(struct bstr *b,
                        const char *label)
 {
     ngli_bstr_printf(b, "    %s_%p -> %s_%p%s\n",
-                    x->class->name, x, y->class->name, y, label);
+                    x->cls->name, x, y->cls->name, y, label);
 }
 
 static void print_links(struct bstr *b, const struct ngl_node *node,
@@ -226,7 +226,7 @@ static void print_all_links(struct bstr *b, const struct ngl_node *node, struct 
         return;
 
     print_links(b, node, ngli_base_node_params, (uint8_t *)node, links);
-    print_links(b, node, node->class->params, node->priv_data, links);
+    print_links(b, node, node->cls->params, node->priv_data, links);
 }
 
 static void print_links(struct bstr *b, const struct ngl_node *node,
@@ -253,7 +253,7 @@ static void print_links(struct bstr *b, const struct ngl_node *node,
 
                 if (nb_children && (p->flags & NGLI_PARAM_FLAG_DOT_DISPLAY_PACKED)) {
                     ngli_bstr_printf(b, "    %s_%p -> %s_%p%s\n",
-                                    node->class->name, node, p->key, children, label);
+                                    node->cls->name, node, p->key, children, label);
                     break;
                 }
 

--- a/libnodegl/gctx.c
+++ b/libnodegl/gctx.c
@@ -60,51 +60,51 @@ struct gctx *ngli_gctx_create(const struct ngl_config *config)
             backend_map[config->backend].string_id);
         return NULL;
     }
-    const struct gctx_class *class = backend_map[config->backend].cls;
-    struct gctx *s = class->create(config);
+    const struct gctx_class *cls = backend_map[config->backend].cls;
+    struct gctx *s = cls->create(config);
     if (!s)
         return NULL;
     s->config = *config;
     s->backend_str = backend_map[config->backend].string_id;
-    s->class = class;
+    s->cls = cls;
     return s;
 }
 
 int ngli_gctx_init(struct gctx *s)
 {
-    return s->class->init(s);
+    return s->cls->init(s);
 }
 
 int ngli_gctx_resize(struct gctx *s, int width, int height, const int *viewport)
 {
-    const struct gctx_class *class = s->class;
-    return class->resize(s, width, height, viewport);
+    const struct gctx_class *cls = s->cls;
+    return cls->resize(s, width, height, viewport);
 }
 
 int ngli_gctx_set_capture_buffer(struct gctx *s, void *capture_buffer)
 {
-    const struct gctx_class *class = s->class;
-    return class->set_capture_buffer(s, capture_buffer);
+    const struct gctx_class *cls = s->cls;
+    return cls->set_capture_buffer(s, capture_buffer);
 }
 
 int ngli_gctx_begin_draw(struct gctx *s, double t)
 {
-    return s->class->begin_draw(s, t);
+    return s->cls->begin_draw(s, t);
 }
 
 int ngli_gctx_end_draw(struct gctx *s, double t)
 {
-    return s->class->end_draw(s, t);
+    return s->cls->end_draw(s, t);
 }
 
 int ngli_gctx_query_draw_time(struct gctx *s, int64_t *time)
 {
-    return s->class->query_draw_time(s, time);
+    return s->cls->query_draw_time(s, time);
 }
 
 void ngli_gctx_wait_idle(struct gctx *s)
 {
-    s->class->wait_idle(s);
+    s->cls->wait_idle(s);
 }
 
 void ngli_gctx_freep(struct gctx **sp)
@@ -113,74 +113,74 @@ void ngli_gctx_freep(struct gctx **sp)
         return;
 
     struct gctx *s = *sp;
-    const struct gctx_class *class = s->class;
-    if (class)
-        class->destroy(s);
+    const struct gctx_class *cls = s->cls;
+    if (cls)
+        cls->destroy(s);
 
     ngli_freep(sp);
 }
 
 int ngli_gctx_transform_cull_mode(struct gctx *s, int cull_mode)
 {
-    return s->class->transform_cull_mode(s, cull_mode);
+    return s->cls->transform_cull_mode(s, cull_mode);
 }
 
 void ngli_gctx_transform_projection_matrix(struct gctx *s, float *dst)
 {
-    s->class->transform_projection_matrix(s, dst);
+    s->cls->transform_projection_matrix(s, dst);
 }
 
 void ngli_gctx_begin_render_pass(struct gctx *s, struct rendertarget *rt)
 {
-    s->class->begin_render_pass(s, rt);
+    s->cls->begin_render_pass(s, rt);
 }
 
 void ngli_gctx_end_render_pass(struct gctx *s)
 {
-    s->class->end_render_pass(s);
+    s->cls->end_render_pass(s);
 }
 
 void ngli_gctx_get_rendertarget_uvcoord_matrix(struct gctx *s, float *dst)
 {
-    s->class->get_rendertarget_uvcoord_matrix(s, dst);
+    s->cls->get_rendertarget_uvcoord_matrix(s, dst);
 }
 
 struct rendertarget *ngli_gctx_get_default_rendertarget(struct gctx *s)
 {
-    return s->class->get_default_rendertarget(s);
+    return s->cls->get_default_rendertarget(s);
 }
 
 const struct rendertarget_desc *ngli_gctx_get_default_rendertarget_desc(struct gctx *s)
 {
-    return s->class->get_default_rendertarget_desc(s);
+    return s->cls->get_default_rendertarget_desc(s);
 }
 
 void ngli_gctx_set_viewport(struct gctx *s, const int *viewport)
 {
-    s->class->set_viewport(s, viewport);
+    s->cls->set_viewport(s, viewport);
 }
 
 void ngli_gctx_get_viewport(struct gctx *s, int *viewport)
 {
-    s->class->get_viewport(s, viewport);
+    s->cls->get_viewport(s, viewport);
 }
 
 void ngli_gctx_set_scissor(struct gctx *s, const int *scissor)
 {
-    s->class->set_scissor(s, scissor);
+    s->cls->set_scissor(s, scissor);
 }
 
 void ngli_gctx_get_scissor(struct gctx *s, int *scissor)
 {
-    s->class->get_scissor(s, scissor);
+    s->cls->get_scissor(s, scissor);
 }
 
 int ngli_gctx_get_preferred_depth_format(struct gctx *s)
 {
-    return s->class->get_preferred_depth_format(s);
+    return s->cls->get_preferred_depth_format(s);
 }
 
 int ngli_gctx_get_preferred_depth_stencil_format(struct gctx *s)
 {
-    return s->class->get_preferred_depth_stencil_format(s);
+    return s->cls->get_preferred_depth_stencil_format(s);
 }

--- a/libnodegl/gctx.h
+++ b/libnodegl/gctx.h
@@ -100,7 +100,7 @@ struct gctx_class {
 struct gctx {
     struct ngl_config config;
     const char *backend_str;
-    const struct gctx_class *class;
+    const struct gctx_class *cls;
     int version;
     int language_version;
     uint64_t features;

--- a/libnodegl/gen_doc.c
+++ b/libnodegl/gen_doc.c
@@ -33,16 +33,16 @@
 #error gen doc can not work with CONFIG_SMALL set
 #endif
 
-#define CLASS_LIST(type_name, class) extern const struct node_class class;
+#define CLASS_LIST(type_name, cls) extern const struct node_class cls;
 NODE_MAP_TYPE2CLASS(CLASS_LIST)
 
 extern const struct node_param ngli_base_node_params[];
 extern const struct param_specs ngli_params_specs[];
 
-#define TYPE2CLASS(type_name, class)            \
+#define TYPE2CLASS(type_name, cls)              \
     case type_name: {                           \
-        extern const struct node_class class;   \
-        return &class;                          \
+        extern const struct node_class cls;     \
+        return &cls;                            \
     }                                           \
 
 static const struct node_class *get_node_class(int type)
@@ -55,11 +55,11 @@ static const struct node_class *get_node_class(int type)
 
 #define LOWER(c) (((c) >= 'A' && (c) <= 'Z') ? (c) ^ 0x20 : (c))
 
-static void print_node_type(struct bstr *b, const struct node_class *class)
+static void print_node_type(struct bstr *b, const struct node_class *cls)
 {
-    const char *class_ref = class->params_id ? class->params_id : class->name;
+    const char *class_ref = cls->params_id ? cls->params_id : cls->name;
 
-    ngli_bstr_printf(b, "[%s](#", class->name);
+    ngli_bstr_printf(b, "[%s](#", cls->name);
     for (int i = 0; class_ref[i]; i++)
         ngli_bstr_printf(b, "%c", LOWER(class_ref[i]));
     ngli_bstr_print(b, ")");
@@ -185,7 +185,7 @@ static void print_choices(const struct param_choices *choices)
     }
 }
 
-#define CLASS_COMMALIST(type_name, class) &class,
+#define CLASS_COMMALIST(type_name, cls) &cls,
 
 static void print_source(const char *cfile)
 {

--- a/libnodegl/gen_specs.c
+++ b/libnodegl/gen_specs.c
@@ -25,7 +25,7 @@
 #include "nodes.h"
 #include "nodes_register.h"
 
-#define CLASS_LIST(type_name, class) extern const struct node_class class;
+#define CLASS_LIST(type_name, cls) extern const struct node_class cls;
 NODE_MAP_TYPE2CLASS(CLASS_LIST)
 
 extern const struct node_param ngli_base_node_params[];
@@ -43,7 +43,7 @@ static void print_node_params(const char *name, const struct node_param *p)
     printf("\n");
 }
 
-#define CLASS_COMMALIST(type_name, class) &class,
+#define CLASS_COMMALIST(type_name, cls) &cls,
 
 int main(void)
 {

--- a/libnodegl/hud.c
+++ b/libnodegl/hud.c
@@ -323,7 +323,7 @@ static int widget_latency_init(struct hud *s, struct widget *widget)
 
 static int track_children_per_types(struct hmap *map, struct ngl_node *node, int node_type)
 {
-    if (node->class->id == node_type) {
+    if (node->cls->id == node_type) {
         char key[32];
         int ret = snprintf(key, sizeof(key), "%p", node);
         if (ret < 0)

--- a/libnodegl/node_animated.c
+++ b/libnodegl/node_animated.c
@@ -169,18 +169,18 @@ static ngli_animation_cpy_func_type get_cpy_func(int node_class)
 
 int ngl_anim_evaluate(struct ngl_node *node, void *dst, double t)
 {
-    if (node->class->id != NGL_NODE_ANIMATEDFLOAT &&
-        node->class->id != NGL_NODE_ANIMATEDVEC2 &&
-        node->class->id != NGL_NODE_ANIMATEDVEC3 &&
-        node->class->id != NGL_NODE_ANIMATEDVEC4 &&
-        node->class->id != NGL_NODE_ANIMATEDQUAT)
+    if (node->cls->id != NGL_NODE_ANIMATEDFLOAT &&
+        node->cls->id != NGL_NODE_ANIMATEDVEC2 &&
+        node->cls->id != NGL_NODE_ANIMATEDVEC3 &&
+        node->cls->id != NGL_NODE_ANIMATEDVEC4 &&
+        node->cls->id != NGL_NODE_ANIMATEDQUAT)
         return NGL_ERROR_INVALID_ARG;
 
     struct variable_priv *s = node->priv_data;
     if (!s->nb_animkf)
         return NGL_ERROR_INVALID_ARG;
 
-    if (node->class->id == NGL_NODE_ANIMATEDQUAT && s->as_mat4) {
+    if (node->cls->id == NGL_NODE_ANIMATEDQUAT && s->as_mat4) {
         LOG(ERROR, "evaluating an AnimatedQuat to a mat4 is not supported");
         return NGL_ERROR_UNSUPPORTED;
     }
@@ -188,8 +188,8 @@ int ngl_anim_evaluate(struct ngl_node *node, void *dst, double t)
     if (!s->anim_eval.kfs) {
         int ret = ngli_animation_init(&s->anim_eval, NULL,
                                       s->animkf, s->nb_animkf,
-                                      get_mix_func(node->class->id),
-                                      get_cpy_func(node->class->id));
+                                      get_mix_func(node->cls->id),
+                                      get_cpy_func(node->cls->id));
         if (ret < 0)
             return ret;
     }
@@ -197,7 +197,7 @@ int ngl_anim_evaluate(struct ngl_node *node, void *dst, double t)
     struct animkeyframe_priv *kf0 = s->animkf[0]->priv_data;
     if (!kf0->function) {
         for (int i = 0; i < s->nb_animkf; i++) {
-            int ret = s->animkf[i]->class->init(s->animkf[i]);
+            int ret = s->animkf[i]->cls->init(s->animkf[i]);
             if (ret < 0)
                 return ret;
         }
@@ -212,8 +212,8 @@ static int animation_init(struct ngl_node *node)
     s->dynamic = 1;
     return ngli_animation_init(&s->anim, NULL,
                                s->animkf, s->nb_animkf,
-                               get_mix_func(node->class->id),
-                               get_cpy_func(node->class->id));
+                               get_mix_func(node->cls->id),
+                               get_cpy_func(node->cls->id));
 }
 
 #define DECLARE_INIT_FUNC(suffix, class_data, class_data_size, class_data_type) \

--- a/libnodegl/node_animkeyframe.c
+++ b/libnodegl/node_animkeyframe.c
@@ -340,29 +340,29 @@ static int animkeyframe_init(struct ngl_node *node)
     const int easing_id = s->easing;
     const char *easing_name = ngli_params_get_select_str(easing_choices.consts, easing_id);
 
-    if (node->class->id == NGL_NODE_ANIMKEYFRAMEVEC2)
+    if (node->cls->id == NGL_NODE_ANIMKEYFRAMEVEC2)
         LOG(VERBOSE, "%s of type %s starting at (%f,%f) for t=%f",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->value[0], s->value[1], s->time);
-    else if (node->class->id == NGL_NODE_ANIMKEYFRAMEVEC3)
+    else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEVEC3)
         LOG(VERBOSE, "%s of type %s starting at (%f,%f,%f) for t=%f",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->value[0], s->value[1], s->value[2], s->time);
-    else if (node->class->id == NGL_NODE_ANIMKEYFRAMEVEC4)
+    else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEVEC4)
         LOG(VERBOSE, "%s of type %s starting at (%f,%f,%f,%f) for t=%f",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->value[0], s->value[1], s->value[2], s->value[3], s->time);
-    else if (node->class->id == NGL_NODE_ANIMKEYFRAMEQUAT)
+    else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEQUAT)
         LOG(VERBOSE, "%s of type %s starting at (%f,%f,%f,%f) for t=%f",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->value[0], s->value[1], s->value[2], s->value[3], s->time);
-    else if (node->class->id == NGL_NODE_ANIMKEYFRAMEFLOAT)
+    else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEFLOAT)
         LOG(VERBOSE, "%s of type %s starting at %f for t=%f",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->scalar, s->time);
-    else if (node->class->id == NGL_NODE_ANIMKEYFRAMEBUFFER)
+    else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEBUFFER)
         LOG(VERBOSE, "%s of type %s starting with t=%f (data size: %d)",
-            node->class->name, easing_name,
+            node->cls->name, easing_name,
             s->time, s->data_size);
     else
         return NGL_ERROR_BUG;
@@ -382,7 +382,7 @@ static int animkeyframe_init(struct ngl_node *node)
 static char *animkeyframe_info_str(const struct ngl_node *node)
 {
     const struct animkeyframe_priv *s = node->priv_data;
-    const struct node_param *params = node->class->params;
+    const struct node_param *params = node->cls->params;
     struct bstr *b = ngli_bstr_create();
 
     if (!b)
@@ -402,9 +402,9 @@ static char *animkeyframe_info_str(const struct ngl_node *node)
         ngli_bstr_printf(b, "on (%g,%g) ", s->offsets[0], s->offsets[1]);
     }
 
-    if (node->class->id == NGL_NODE_ANIMKEYFRAMEBUFFER) {
+    if (node->cls->id == NGL_NODE_ANIMKEYFRAMEBUFFER) {
         ngli_bstr_printf(b, "with data size of %dB", s->data_size);
-    } else if (node->class->id == NGL_NODE_ANIMKEYFRAMEQUAT) {
+    } else if (node->cls->id == NGL_NODE_ANIMKEYFRAMEQUAT) {
         ngli_bstr_printf(b, "with quat=(%g,%g,%g,%g)", NGLI_ARG_VEC4(s->value));
     } else {
         ngli_bstr_print(b, "with v=");

--- a/libnodegl/node_block.c
+++ b/libnodegl/node_block.c
@@ -177,10 +177,10 @@ int ngli_node_block_upload(struct ngl_node *node)
 
 static int get_node_data_type(const struct ngl_node *node)
 {
-    if (node->class->category == NGLI_NODE_CATEGORY_UNIFORM) {
+    if (node->cls->category == NGLI_NODE_CATEGORY_UNIFORM) {
         const struct variable_priv *variable = node->priv_data;
         return variable->data_type;
-    } else if (node->class->category == NGLI_NODE_CATEGORY_BUFFER) {
+    } else if (node->cls->category == NGLI_NODE_CATEGORY_BUFFER) {
         const struct buffer_priv *buffer = node->priv_data;
         return buffer->data_type;
     } else {
@@ -190,9 +190,9 @@ static int get_node_data_type(const struct ngl_node *node)
 
 static int get_node_data_count(const struct ngl_node *node)
 {
-    if (node->class->category == NGLI_NODE_CATEGORY_UNIFORM) {
+    if (node->cls->category == NGLI_NODE_CATEGORY_UNIFORM) {
         return 0;
-    } else if (node->class->category == NGLI_NODE_CATEGORY_BUFFER) {
+    } else if (node->cls->category == NGLI_NODE_CATEGORY_BUFFER) {
         const struct buffer_priv *buffer = node->priv_data;
         return buffer->count;
     } else {

--- a/libnodegl/node_buffer.c
+++ b/libnodegl/node_buffer.c
@@ -214,9 +214,9 @@ static int buffer_init_from_block(struct ngl_node *node)
     }
 
     struct ngl_node *buffer_target = block->fields[s->block_field];
-    if (buffer_target->class->id != node->class->id) {
+    if (buffer_target->cls->id != node->cls->id) {
         LOG(ERROR, "%s[%d] of type %s mismatches %s local type",
-            s->block->label, s->block_field, buffer_target->class->name, node->class->name);
+            s->block->label, s->block_field, buffer_target->cls->name, node->cls->name);
         return NGL_ERROR_INVALID_ARG;
     }
 
@@ -249,7 +249,7 @@ static int buffer_init(struct ngl_node *node)
         return NGL_ERROR_INVALID_ARG;
     }
 
-    if (node->class->id == NGL_NODE_BUFFERMAT4) {
+    if (node->cls->id == NGL_NODE_BUFFERMAT4) {
         s->data_comp = 4 * 4;
         s->data_stride = s->data_comp * sizeof(float);
     } else {

--- a/libnodegl/node_rtt.c
+++ b/libnodegl/node_rtt.c
@@ -122,10 +122,10 @@ static void get_renderpass_children_info(const struct ngl_node *node, struct ren
     const struct ngl_node **children = ngli_darray_data(&node->children);
     for (int i = 0; i < ngli_darray_count(&node->children); i++) {
         const struct ngl_node *child = children[i];
-        if (child->class->id == NGL_NODE_RENDERTOTEXTURE ||
-            child->class->id == NGL_NODE_COMPUTE) {
+        if (child->cls->id == NGL_NODE_RENDERTOTEXTURE ||
+            child->cls->id == NGL_NODE_COMPUTE) {
             info->has_rtt_or_compute = 1;
-        } else if (child->class->id == NGL_NODE_RENDER) {
+        } else if (child->cls->id == NGL_NODE_RENDER) {
             info->render_counts[info->has_rtt_or_compute ? 1 : 0] += 1;
         } else {
             get_renderpass_children_info(child, info);

--- a/libnodegl/node_texture.c
+++ b/libnodegl/node_texture.c
@@ -261,7 +261,7 @@ static int texture_prefetch(struct ngl_node *node)
     const uint8_t *data = NULL;
 
     if (s->data_src) {
-        switch (s->data_src->class->id) {
+        switch (s->data_src->cls->id) {
         case NGL_NODE_MEDIA:
             return 0;
         case NGL_NODE_ANIMATEDBUFFERFLOAT:
@@ -370,7 +370,7 @@ static int texture_update(struct ngl_node *node, double t)
     if (ret < 0)
         return ret;
 
-    switch (s->data_src->class->id) {
+    switch (s->data_src->cls->id) {
         case NGL_NODE_MEDIA:
             handle_media_frame(node);
             break;

--- a/libnodegl/node_timerangefilter.c
+++ b/libnodegl/node_timerangefilter.c
@@ -119,7 +119,7 @@ static int update_rr_state(struct timerangefilter_priv *s, double t)
             // We leave our current render range, so we reset the "Once" flag
             // for next time we may come in again (seek back)
             struct ngl_node *cur_rr = s->ranges[s->current_range];
-            if (cur_rr->class->id == NGL_NODE_TIMERANGEMODEONCE) {
+            if (cur_rr->cls->id == NGL_NODE_TIMERANGEMODEONCE) {
                 struct timerangemode_priv *rro = cur_rr->priv_data;
                 rro->updated = 0;
             }
@@ -149,7 +149,7 @@ static int timerangefilter_visit(struct ngl_node *node, int is_active, double t)
 
             s->current_range = rr_id;
 
-            if (rr->class->id == NGL_NODE_TIMERANGEMODENOOP) {
+            if (rr->cls->id == NGL_NODE_TIMERANGEMODENOOP) {
                 is_active = 0;
 
                 if (rr_id < s->nb_ranges - 1) {
@@ -177,7 +177,7 @@ static int timerangefilter_visit(struct ngl_node *node, int is_active, double t)
                         is_active = 1;
                     }
                 }
-            } else if (rr->class->id == NGL_NODE_TIMERANGEMODEONCE) {
+            } else if (rr->cls->id == NGL_NODE_TIMERANGEMODEONCE) {
                 // If the child of the current once range is inactive, meaning
                 // it has been previously released, we need to force an update
                 // otherwise the child will stay uninitialized.
@@ -202,10 +202,10 @@ static int timerangefilter_update(struct ngl_node *node, double t)
     if (rr_id >= 0) {
         struct ngl_node *rr = s->ranges[rr_id];
 
-        if (rr->class->id == NGL_NODE_TIMERANGEMODENOOP)
+        if (rr->cls->id == NGL_NODE_TIMERANGEMODENOOP)
             return 0;
 
-        if (rr->class->id == NGL_NODE_TIMERANGEMODEONCE) {
+        if (rr->cls->id == NGL_NODE_TIMERANGEMODEONCE) {
             struct timerangemode_priv *rro = rr->priv_data;
             if (rro->updated)
                 return 0;

--- a/libnodegl/nodes.h
+++ b/libnodegl/nodes.h
@@ -103,7 +103,7 @@ struct ngl_ctx {
 };
 
 struct ngl_node {
-    const struct node_class *class;
+    const struct node_class *cls;
     struct ngl_ctx *ctx;
 
     int state;

--- a/libnodegl/params.c
+++ b/libnodegl/params.c
@@ -318,7 +318,7 @@ static int allowed_node(const struct ngl_node *node, const int *allowed_ids)
 {
     if (!allowed_ids)
         return 1;
-    const int id = node->class->id;
+    const int id = node->cls->id;
     for (int i = 0; allowed_ids[i] != -1; i++)
         if (id == allowed_ids[i])
             return 1;
@@ -482,7 +482,7 @@ int ngli_params_set(uint8_t *base_ptr, const struct node_param *par, va_list *ap
             struct ngl_node *node = va_arg(*ap, struct ngl_node *);
             if (!allowed_node(node, par->node_types)) {
                 LOG(ERROR, "%s (%s) is not an allowed type for %s",
-                    node->label, node->class->name, par->key);
+                    node->label, node->cls->name, par->key);
                 return NGL_ERROR_INVALID_ARG;
             }
             ngl_node_unrefp((struct ngl_node **)dstp);
@@ -497,7 +497,7 @@ int ngli_params_set(uint8_t *base_ptr, const struct node_param *par, va_list *ap
             struct ngl_node *node = va_arg(*ap, struct ngl_node *);
             if (node && !allowed_node(node, par->node_types)) {
                 LOG(ERROR, "%s (%s) is not an allowed type for %s",
-                    node->label, node->class->name, par->key);
+                    node->label, node->cls->name, par->key);
                 return NGL_ERROR_INVALID_ARG;
             }
             LOG(VERBOSE, "set %s to (%s,%p)", par->key, name, node);
@@ -639,7 +639,7 @@ int ngli_params_add(uint8_t *base_ptr, const struct node_param *par,
                 const struct ngl_node *e = add_elems[i];
                 if (!allowed_node(e, par->node_types)) {
                     LOG(ERROR, "%s (%s) is not an allowed type for %s list",
-                        e->label, e->class->name, par->key);
+                        e->label, e->cls->name, par->key);
                     return NGL_ERROR_INVALID_ARG;
                 }
             }

--- a/libnodegl/pass.c
+++ b/libnodegl/pass.c
@@ -60,12 +60,12 @@ static int register_uniform(struct pass *s, const char *name, struct ngl_node *u
     struct pgcraft_uniform crafter_uniform = {.stage = stage};
     snprintf(crafter_uniform.name, sizeof(crafter_uniform.name), "%s", name);
 
-    if (uniform->class->category == NGLI_NODE_CATEGORY_BUFFER) {
+    if (uniform->cls->category == NGLI_NODE_CATEGORY_BUFFER) {
         struct buffer_priv *buffer_priv = uniform->priv_data;
         crafter_uniform.type  = buffer_priv->data_type;
         crafter_uniform.count = buffer_priv->count;
         crafter_uniform.data  = buffer_priv->data;
-    } else if (uniform->class->category == NGLI_NODE_CATEGORY_UNIFORM) {
+    } else if (uniform->cls->category == NGLI_NODE_CATEGORY_UNIFORM) {
         struct variable_priv *variable_priv = uniform->priv_data;
         crafter_uniform.type  = variable_priv->data_type;
         crafter_uniform.data  = variable_priv->data;
@@ -124,7 +124,7 @@ static int register_texture(struct pass *s, const char *name, struct ngl_node *t
     };
     snprintf(crafter_texture.name, sizeof(crafter_texture.name), "%s", name);
 
-    switch (texture->class->id) {
+    switch (texture->cls->id) {
     case NGL_NODE_TEXTURE2D:   crafter_texture.type = NGLI_PGCRAFT_SHADER_TEX_TYPE_TEXTURE2D; break;
     case NGL_NODE_TEXTURE3D:   crafter_texture.type = NGLI_PGCRAFT_SHADER_TEX_TYPE_TEXTURE3D; break;
     case NGL_NODE_TEXTURECUBE: crafter_texture.type = NGLI_PGCRAFT_SHADER_TEX_TYPE_CUBE;      break;
@@ -138,7 +138,7 @@ static int register_texture(struct pass *s, const char *name, struct ngl_node *t
         if (resprops_node) {
             const struct resourceprops_priv *resprops = resprops_node->priv_data;
             if (resprops->as_image) {
-                if (texture->class->id != NGL_NODE_TEXTURE2D) {
+                if (texture->cls->id != NGL_NODE_TEXTURE2D) {
                     LOG(ERROR, "\"%s\" can not be accessed as an image; only Texture2D is supported as image", name);
                     return NGL_ERROR_UNSUPPORTED;
                 }
@@ -333,7 +333,7 @@ static int register_attribute(struct pass *s, const char *name, struct ngl_node 
 
 static int register_resource(struct pass *s, const char *name, struct ngl_node *node, int stage)
 {
-    switch (node->class->category) {
+    switch (node->cls->category) {
     case NGLI_NODE_CATEGORY_UNIFORM:
     case NGLI_NODE_CATEGORY_BUFFER:  return register_uniform(s, name, node, stage);
     case NGLI_NODE_CATEGORY_TEXTURE: return register_texture(s, name, node, stage);

--- a/libnodegl/pipeline.c
+++ b/libnodegl/pipeline.c
@@ -25,57 +25,57 @@
 
 struct pipeline *ngli_pipeline_create(struct gctx *gctx)
 {
-    return gctx->class->pipeline_create(gctx);
+    return gctx->cls->pipeline_create(gctx);
 }
 
 int ngli_pipeline_init(struct pipeline *s, const struct pipeline_params *params)
 {
-    return s->gctx->class->pipeline_init(s, params);
+    return s->gctx->cls->pipeline_init(s, params);
 }
 
 int ngli_pipeline_set_resources(struct pipeline *s, const struct pipeline_resource_params *data_params)
 {
-    return s->gctx->class->pipeline_set_resources(s, data_params);
+    return s->gctx->cls->pipeline_set_resources(s, data_params);
 }
 
 int ngli_pipeline_update_attribute(struct pipeline *s, int index, struct buffer *buffer)
 {
-    return s->gctx->class->pipeline_update_attribute(s, index, buffer);
+    return s->gctx->cls->pipeline_update_attribute(s, index, buffer);
 }
 
 int ngli_pipeline_update_uniform(struct pipeline *s, int index, const void *value)
 {
-    return s->gctx->class->pipeline_update_uniform(s, index, value);
+    return s->gctx->cls->pipeline_update_uniform(s, index, value);
 }
 
 int ngli_pipeline_update_texture(struct pipeline *s, int index, struct texture *texture)
 {
-    return s->gctx->class->pipeline_update_texture(s, index, texture);
+    return s->gctx->cls->pipeline_update_texture(s, index, texture);
 }
 
 int ngli_pipeline_update_buffer(struct pipeline *s, int index, struct buffer *buffer)
 {
-    return s->gctx->class->pipeline_update_buffer(s, index, buffer);
+    return s->gctx->cls->pipeline_update_buffer(s, index, buffer);
 }
 
 void ngli_pipeline_draw(struct pipeline *s, int nb_vertices, int nb_instances)
 {
-    s->gctx->class->pipeline_draw(s, nb_vertices, nb_instances);
+    s->gctx->cls->pipeline_draw(s, nb_vertices, nb_instances);
 }
 
 void ngli_pipeline_draw_indexed(struct pipeline *s, struct buffer *indices, int indices_format, int nb_indices, int nb_instances)
 {
-    s->gctx->class->pipeline_draw_indexed(s, indices, indices_format, nb_indices, nb_instances);
+    s->gctx->cls->pipeline_draw_indexed(s, indices, indices_format, nb_indices, nb_instances);
 }
 
 void ngli_pipeline_dispatch(struct pipeline *s, int nb_group_x, int nb_group_y, int nb_group_z)
 {
-    s->gctx->class->pipeline_dispatch(s, nb_group_x, nb_group_y, nb_group_z);
+    s->gctx->cls->pipeline_dispatch(s, nb_group_x, nb_group_y, nb_group_z);
 }
 
 void ngli_pipeline_freep(struct pipeline **sp)
 {
     if (!*sp)
         return;
-    (*sp)->gctx->class->pipeline_freep(sp);
+    (*sp)->gctx->cls->pipeline_freep(sp);
 }

--- a/libnodegl/program.c
+++ b/libnodegl/program.c
@@ -24,17 +24,17 @@
 
 struct program *ngli_program_create(struct gctx *gctx)
 {
-    return gctx->class->program_create(gctx);
+    return gctx->cls->program_create(gctx);
 }
 
 int ngli_program_init(struct program *s, const char *vertex, const char *fragment, const char *compute)
 {
-    return s->gctx->class->program_init(s, vertex, fragment, compute);
+    return s->gctx->cls->program_init(s, vertex, fragment, compute);
 }
 
 void ngli_program_freep(struct program **sp)
 {
     if (!*sp)
         return;
-    (*sp)->gctx->class->program_freep(sp);
+    (*sp)->gctx->cls->program_freep(sp);
 }

--- a/libnodegl/rendertarget.c
+++ b/libnodegl/rendertarget.c
@@ -24,22 +24,22 @@
 
 struct rendertarget *ngli_rendertarget_create(struct gctx *gctx)
 {
-    return gctx->class->rendertarget_create(gctx);
+    return gctx->cls->rendertarget_create(gctx);
 }
 
 int ngli_rendertarget_init(struct rendertarget *s, const struct rendertarget_params *params)
 {
-    return s->gctx->class->rendertarget_init(s, params);
+    return s->gctx->cls->rendertarget_init(s, params);
 }
 
 void ngli_rendertarget_read_pixels(struct rendertarget *s, uint8_t *data)
 {
-    s->gctx->class->rendertarget_read_pixels(s, data);
+    s->gctx->cls->rendertarget_read_pixels(s, data);
 }
 
 void ngli_rendertarget_freep(struct rendertarget **sp)
 {
     if (!*sp)
         return;
-    (*sp)->gctx->class->rendertarget_freep(sp);
+    (*sp)->gctx->cls->rendertarget_freep(sp);
 }

--- a/libnodegl/serialize.c
+++ b/libnodegl/serialize.c
@@ -193,7 +193,7 @@ static int serialize_options(struct hmap *nlist,
                 if (!s || (p->def_value.str && !strcmp(s, p->def_value.str)))
                     break;
                 if (!strcmp(p->key, "label") &&
-                    ngli_is_default_label(node->class->name, s))
+                    ngli_is_default_label(node->cls->name, s))
                     break;
                 ngli_bstr_printf(b, " %s:", p->key);
                 for (int i = 0; s[i]; i++)
@@ -385,16 +385,16 @@ static int serialize(struct hmap *nlist,
     int ret;
 
     if ((ret = serialize_children(nlist, b, node, (uint8_t *)node, ngli_base_node_params)) < 0 ||
-        (ret = serialize_children(nlist, b, node, node->priv_data, node->class->params)) < 0)
+        (ret = serialize_children(nlist, b, node, node->priv_data, node->cls->params)) < 0)
         return ret;
 
-    const uint32_t tag = node->class->id;
+    const uint32_t tag = node->cls->id;
     ngli_bstr_printf(b, "%c%c%c%c",
                     tag >> 24 & 0xff,
                     tag >> 16 & 0xff,
                     tag >>  8 & 0xff,
                     tag       & 0xff);
-    if ((ret = serialize_options(nlist, b, node, node->priv_data, node->class->params)) < 0 ||
+    if ((ret = serialize_options(nlist, b, node, node->priv_data, node->cls->params)) < 0 ||
         (ret = serialize_options(nlist, b, node, (uint8_t *)node, ngli_base_node_params)) < 0)
         return ret;
 

--- a/libnodegl/texture.c
+++ b/libnodegl/texture.c
@@ -24,37 +24,37 @@
 
 struct texture *ngli_texture_create(struct gctx *gctx)
 {
-    return gctx->class->texture_create(gctx);
+    return gctx->cls->texture_create(gctx);
 }
 
 int ngli_texture_init(struct texture *s, const struct texture_params *params)
 {
-    return s->gctx->class->texture_init(s, params);
+    return s->gctx->cls->texture_init(s, params);
 }
 
 int ngli_texture_has_mipmap(const struct texture *s)
 {
-    return s->gctx->class->texture_has_mipmap(s);
+    return s->gctx->cls->texture_has_mipmap(s);
 }
 
 int ngli_texture_match_dimensions(const struct texture *s, int width, int height, int depth)
 {
-    return s->gctx->class->texture_match_dimensions(s, width, height, depth);
+    return s->gctx->cls->texture_match_dimensions(s, width, height, depth);
 }
 
 int ngli_texture_upload(struct texture *s, const uint8_t *data, int linesize)
 {
-    return s->gctx->class->texture_upload(s, data, linesize);
+    return s->gctx->cls->texture_upload(s, data, linesize);
 }
 
 int ngli_texture_generate_mipmap(struct texture *s)
 {
-    return s->gctx->class->texture_generate_mipmap(s);
+    return s->gctx->cls->texture_generate_mipmap(s);
 }
 
 void ngli_texture_freep(struct texture **sp)
 {
     if (!*sp)
         return;
-    (*sp)->gctx->class->texture_freep(sp);
+    (*sp)->gctx->cls->texture_freep(sp);
 }

--- a/libnodegl/transforms.c
+++ b/libnodegl/transforms.c
@@ -28,7 +28,7 @@
 const float *ngli_get_last_transformation_matrix(const struct ngl_node *node)
 {
     while (node) {
-        const int id = node->class->id;
+        const int id = node->cls->id;
         switch (id) {
             case NGL_NODE_ROTATE:
             case NGL_NODE_ROTATEQUAT:
@@ -46,7 +46,7 @@ const float *ngli_get_last_transformation_matrix(const struct ngl_node *node)
             }
             default:
                 LOG(ERROR, "%s (%s) is not an allowed type for a camera transformation",
-                    node->label, node->class->name);
+                    node->label, node->cls->name);
                 break;
         }
     }


### PR DESCRIPTION
We should avoid using C++ keywords, especially in headers, so that
node.gl code can be used from both C and C++