### PR TITLE
ngl-tools: instruct NSView to create a layer

### DIFF
--- a/ngl-tools/wsi_cocoa.m
+++ b/ngl-tools/wsi_cocoa.m
@@ -38,6 +38,7 @@ int wsi_set_ngl_config(struct ngl_config *config, SDL_Window *window)
     if (info.subsystem == SDL_SYSWM_COCOA) {
         NSWindow *nswindow = info.info.cocoa.window;
         NSView *view = [nswindow contentView];
+        view.wantsLayer = YES;
         config->platform = NGL_PLATFORM_MACOS;
         config->window = (uintptr_t)view;
         return 0;


### PR DESCRIPTION
The NSView can optionally be backed by a layer, which is a buffer that
stores the view contents.  We want to back the view by a layer,
so that we can draw directly to it