### PR TITLE
pynodegl-utils: use a normalized path that works across all platforms (including WSL)

### DIFF
--- a/pynodegl-utils/pynodegl_utils/controller.py
+++ b/pynodegl-utils/pynodegl_utils/controller.py
@@ -22,7 +22,7 @@
 
 import sys
 import os.path as op
-
+from pynodegl_utils.path_util import path_join
 from PySide2 import QtWidgets, QtCore
 
 from .ui.main_window import MainWindow
@@ -34,8 +34,9 @@ def run():
     parser = argparse.ArgumentParser()
     parser.add_argument('-m', dest='module', default='pynodegl_utils.examples',
                         help='set the module name containing the scene functions')
+    default_hooks_dir = path_norm(op.join(op.dirname(__file__), 'hooks', 'desktop'))
     parser.add_argument('--hooks-dir', dest='hooksdirs',
-                        default=[op.join(op.dirname(__file__), 'hooks', 'desktop')],
+                        default=[default_hooks_dir],
                         action='append',
                         help='set the directory path containing event hooks')
     pargs = parser.parse_args(sys.argv[1:])

--- a/pynodegl-utils/pynodegl_utils/hooks.py
+++ b/pynodegl-utils/pynodegl_utils/hooks.py
@@ -28,6 +28,7 @@ import subprocess
 import time
 
 from PySide2 import QtCore
+from pynodegl_utils.path_util import path_norm
 
 
 class _HooksCaller:
@@ -89,6 +90,7 @@ class _HooksCaller:
         return uint_color
 
     def scene_change(self, session_id, local_scene, cfg):
+        local_scene = path_norm(local_scene)
         self._get_hook_output(
             'scene_change',
             session_id,

--- a/pynodegl-utils/pynodegl_utils/path_util.py
+++ b/pynodegl-utils/pynodegl_utils/path_util.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 GoPro Inc.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import platform
+import os.path as op
+
+def path_norm(p):
+    if platform.system() == 'Windows':
+        # This is a trick to produce a path that works in both WSL and Windows
+        p = op.relpath(p)
+        p = p.replace('\\','/')
+    return p


### PR DESCRIPTION
The main motivation for this PR is to simplify porting ngl-desktop to windows.

WSL paths are not compatible with Windows paths. 

For example:
WSL path: /mnt/c/Program\ Files
Windows path: C:\Program Files

This code creates a path that is compatible with both WSL and windows (as well as other platforms).  