### PR TITLE
pynodegl-utils: add log messages for test passed / failed

### DIFF
--- a/pynodegl-utils/pynodegl_utils/tests/__init__.py
+++ b/pynodegl-utils/pynodegl_utils/tests/__init__.py
@@ -141,7 +141,8 @@ def run():
     test_func = _refgen_map[refgen_opt]
     err = test_func(func_name, tester, ref_filepath, dump)
     if err:
+        sys.stderr.write(f'{func_name} failed\n')
         sys.stderr.write('\n'.join(err) + '\n')
         sys.exit(1)
-
+    print(f'{func_name} passed')
     sys.exit(0)


### PR DESCRIPTION
Currently, we only have an exit code to indicate if the test passed or failed.  
This makes it more clear to the user if the test passed or failed, especially if running the test manually (not via meson)