### PR TITLE
pynodegl-utils: add dll search directories

### DIFF
--- a/pynodegl-utils/pynodegl_utils/tests/__init__.py
+++ b/pynodegl-utils/pynodegl_utils/tests/__init__.py
@@ -23,6 +23,15 @@
 import os
 import os.path as op
 import sys
+import platform
+
+
+if platform.system() == 'Windows':
+    env_path = os.getenv('PATH').split(';')
+    for p in env_path:
+        if op.exists(p):
+            os.add_dll_directory(p)
+
 
 from pynodegl_utils.com import load_script
 


### PR DESCRIPTION
 The main benefit of this PR is that it allows us to avoid copying the DLLs to multiple directories (and hence simplify the build and runtime environment).  

Currently, when loading a python module, the DLL search path is set to the directory containing the python module.
It doesn't search the directories specified in PATH environment variable.
see https://bugs.python.org/issue43173
With this change, we add the directories in PATH environment variable, along with the venv/Scripts folder as DLL search paths on Windows. 

