### PR TITLE
tools/ipc: use closesocket() instead of close() on Windows

### DIFF
--- a/ngl-tools/ngl-ipc.c
+++ b/ngl-tools/ngl-ipc.c
@@ -382,6 +382,10 @@ end:
     ipc_pkt_freep(&s.send_pkt);
     ipc_pkt_freep(&s.recv_pkt);
     if (fd != -1)
+#ifdef _WIN32
+        closesocket(fd);
+#else
         close(fd);
+#endif
     return ret;
 }


### PR DESCRIPTION
On Windows/MSVC, close() cannot be used on sockets.

This commits prevents ngl-ipc from exiting prematurely (with an error
code different from 0) and allows ngl-ipc to be used by the
pynodegl-utils hooks.