### PR TITLE
build/nodegl: bugfix: don't override search directory when calling cc…

### DIFF
--- a/libnodegl/meson.build
+++ b/libnodegl/meson.build
@@ -391,10 +391,14 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
   foreach dep : host_backend_cfg.get('deps', [])
     gbackend_deps += dependency(dep, required: opt_gbackend)
   endforeach
-  foreach dep : host_backend_cfg.get('libs', [])
-    # XXX: dirs is a hack for MoltenVK; it will break for libraries that are
-    # outside the destination prefix
-    gbackend_deps += cc.find_library(dep, required: opt_gbackend, dirs: get_option('prefix') / get_option('libdir'))
+  foreach lib : host_backend_cfg.get('libs', [])
+    dep = cc.find_library(lib, required: opt_gbackend)
+    if not opt_gbackend.disabled() and not dep.found()
+        # XXX: dirs is a hack for MoltenVK; it will break for libraries that are
+        # outside the destination prefix
+        dep = cc.find_library(lib, required: opt_gbackend, dirs: get_option('prefix') / get_option('libdir'))
+    endif
+    gbackend_deps += dep
   endforeach
   if 'frameworks' in host_backend_cfg
     gbackend_deps += dependency('appleframeworks', modules: host_backend_cfg.get('frameworks'), required: opt_gbackend)


### PR DESCRIPTION
….find_library.

By default, cc.find_library searches for a library in the system library paths.
When passing dirs param, it will check in the user-specified directories instead.
With this fix, meson first searches for the library in the system path, then
if it can't find the library it will search in the user-specified path.

Resolves issue:
Library OpenGL32 found: NO
Library gdi32 found: NO