### PR TITLE
ci/linux,coverge: use actions/checkout version 2

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,7 +19,7 @@ jobs:
             run_tests_command: "MESA_GLES_VERSION_OVERRIDE=2.0 DEBUG=yes DEBUG_GL=yes make -k -j$(($(nproc)+1)) tests TESTS_SUITE=opengles"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_mingw.yml
+++ b/.github/workflows/ci_mingw.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'master'
   pull_request:
-  schedule:
-      - cron: "0 0 * * 6"  # Run every Saturday at midnight
 
 jobs:
   mingw:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and API can change at any time.
 
 ![tests Linux](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Linux/badge.svg)
 ![tests Mac](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Mac/badge.svg)
-![tests Windows](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20Windows/badge.svg)
+![tests MinGW](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20MinGW/badge.svg)
+![tests MSVC](https://github.com/gopro/gopro-lib-node.gl/workflows/tests%20MSVC/badge.svg)
 [![coverage](https://codecov.io/gh/gopro/gopro-lib-node.gl/branch/master/graph/badge.svg)](https://codecov.io/gh/gopro/gopro-lib-node.gl)
 
 [gopro]: https://gopro.com/


### PR DESCRIPTION
This speeds up the checkout as it uses git clone --depth 1 by default.