### PR TITLE
build: misc part 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 builddir
 venv/
+.venv-done


### PR DESCRIPTION
Add logic to indicate when prefix target actually completes.
This improves error handling.  Currently make thinks prefix target
is completed when the folder is created.
However, the prefix target may fail after the folder is created.