### PR TITLE
build: misc part 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,6 @@ else
 PREFIX_FULLPATH = $(PWD)/$(PREFIX)
 endif
 
-PYTHON_MAJOR = 3
-
 #
 # User configuration
 #
@@ -39,7 +37,7 @@ COVERAGE   ?= no
 ifeq ($(TARGET_OS),Windows)
 PYTHON     ?= python.exe
 else
-PYTHON     ?= python$(if $(shell which python$(PYTHON_MAJOR) 2> /dev/null),$(PYTHON_MAJOR),)
+PYTHON     ?= python3
 endif
 
 DEBUG_GL    ?= no
@@ -61,10 +59,6 @@ PKG_CONF_DIR = external\\pkgconf\\build
 CMD = cmd.exe /C @
 else
 CMD =
-endif
-
-ifneq ($(shell $(CMD) $(PYTHON) -c "import sys;print(sys.version_info.major)"),$(PYTHON_MAJOR))
-$(error "Python $(PYTHON_MAJOR) not found")
 endif
 
 ifeq ($(TARGET_OS),Windows)

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,10 @@ DEBUG      ?= no
 COVERAGE   ?= no
 ifeq ($(TARGET_OS),Windows)
 PYTHON     ?= python.exe
+PIP = $(PREFIX)/Scripts/pip.exe
 else
 PYTHON     ?= python3
+PIP = PKG_CONFIG_PATH=$(PREFIX_FULLPATH)/lib/pkgconfig LDFLAGS=$(RPATH_LDFLAGS) $(PREFIX)/bin/pip
 endif
 
 DEBUG_GL    ?= no
@@ -53,40 +55,37 @@ $(info PREFIX_FULLPATH: $(PREFIX_FULLPATH))
 
 ifeq ($(TARGET_OS),Windows)
 VCPKG_DIR ?= C:\\vcpkg
+VCPKG_DIR_WSL = $(shell wslpath -a "$(VCPKG_DIR)")
 PKG_CONF_DIR = external\\pkgconf\\build
-# General way to call cmd from bash: https://github.com/microsoft/WSL/issues/2835
-# Add the character @ after /C
-CMD = cmd.exe /C @
-else
-CMD =
 endif
 
 ifeq ($(TARGET_OS),Windows)
-ACTIVATE = $(CMD) "$(PREFIX_FULLPATH)\\Scripts\\activate.bat"
+ACTIVATE = . $(PREFIX)/Scripts/activate
 else
-ACTIVATE = . $(PREFIX_FULLPATH)/bin/activate
+ACTIVATE = . $(PREFIX)/bin/activate
 endif
 
 RPATH_LDFLAGS ?= -Wl,-rpath,$(PREFIX_FULLPATH)/lib
 
 ifeq ($(TARGET_OS),Windows)
+MESON = meson.exe
 MESON_SETUP_PARAMS  = \
     --prefix="$(PREFIX_FULLPATH)" --bindir="$(PREFIX_FULLPATH)\\Scripts" --includedir="$(PREFIX_FULLPATH)\\Include" \
     --libdir="$(PREFIX_FULLPATH)\\Lib" --pkg-config-path="$(VCPKG_DIR)\\installed\x64-windows\\lib\\pkgconfig;$(PREFIX_FULLPATH)\\Lib\\pkgconfig" -Drpath=true
-MESON_SETUP         = meson setup --backend vs $(MESON_SETUP_PARAMS)
-MESON_SETUP_NINJA   = meson setup --backend ninja $(MESON_SETUP_PARAMS)
+MESON_SETUP         = $(MESON) setup --backend vs $(MESON_SETUP_PARAMS)
+MESON_SETUP_NINJA   = $(MESON) setup --backend ninja $(MESON_SETUP_PARAMS)
 else
-MESON_SETUP         = meson setup --prefix=$(PREFIX_FULLPATH) --pkg-config-path=$(PREFIX_FULLPATH)/lib/pkgconfig -Drpath=true
+MESON = meson
+MESON_SETUP         = $(MESON) setup --prefix=$(PREFIX_FULLPATH) --pkg-config-path=$(PREFIX_FULLPATH)/lib/pkgconfig -Drpath=true
 endif
+
 # MAKEFLAGS= is a workaround (not working on Windows due to incompatible Make
 # syntax) for the issue described here:
 # https://github.com/ninja-build/ninja/issues/1139#issuecomment-724061270
-ifeq ($(TARGET_OS),Windows)
-MESON_COMPILE = meson compile -j8
-else
-MESON_COMPILE = MAKEFLAGS= meson compile -j8
-endif
-MESON_INSTALL = meson install
+MESON_COMPILE = MAKEFLAGS= $(MESON) compile -j8
+
+MESON_INSTALL = $(MESON) install
+
 ifeq ($(COVERAGE),yes)
 MESON_SETUP += -Db_coverage=true
 DEBUG = yes
@@ -136,32 +135,14 @@ all: ngl-tools-install pynodegl-utils-install
 	@echo "    Install completed."
 	@echo
 	@echo "    You can now enter the venv with:"
-ifeq ($(TARGET_OS),Windows)
-	@echo "        (via Windows Command Prompt)"
-	@echo "            cmd.exe"
-	@echo "            $(PREFIX)\\\Scripts\\\activate.bat"
-	@echo "        (via Windows PowerShell)"
-	@echo "            powershell.exe"
-	@echo "            $(PREFIX)\\\Scripts\\\Activate.ps1"
-else
 	@echo "        $(ACTIVATE)"
-endif
 	@echo
 
 ngl-tools-install: nodegl-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP) ngl-tools builddir\\ngl-tools \&\& $(MESON_COMPILE) -C builddir\\ngl-tools \&\& $(MESON_INSTALL) -C builddir\\ngl-tools)
-	$(CMD) xcopy /Y builddir\\ngl-tools\\*.dll "$(PREFIX_FULLPATH)\\Scripts\\."
-else
 	($(ACTIVATE) && $(MESON_SETUP) ngl-tools builddir/ngl-tools && $(MESON_COMPILE) -C builddir/ngl-tools && $(MESON_INSTALL) -C builddir/ngl-tools)
-endif
 
 pynodegl-utils-install: pynodegl-utils-deps-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& pip -v install -e pynodegl-utils)
-else
-	($(ACTIVATE) && pip -v install -e ./pynodegl-utils)
-endif
+	($(ACTIVATE) && $(PIP) -v install -e ./pynodegl-utils)
 
 #
 # pynodegl-install is in dependency to prevent from trying to install pynodegl
@@ -182,34 +163,22 @@ endif
 # decorator and other related utils.
 #
 pynodegl-utils-deps-install: pynodegl-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& pip install -r pynodegl-utils\\requirements.txt)
-else ifneq ($(TARGET_OS),MinGW-w64)
-	($(ACTIVATE) && pip install -r ./pynodegl-utils/requirements.txt)
+ifneq ($(TARGET_OS),MinGW-w64)
+	($(ACTIVATE) && $(PIP) install -r ./pynodegl-utils/requirements.txt)
 endif
 
 pynodegl-install: pynodegl-deps-install
+	($(ACTIVATE) && $(PIP) -v install -e ./pynodegl)
 ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& pip -v install -e .\\pynodegl)
 	# TODO: call add_dll_directory in pynodegl to add DLL search paths
-	$(CMD) xcopy /Y "$(PREFIX_FULLPATH)\Scripts\*.dll" pynodegl\\.
-else
-	($(ACTIVATE) && PKG_CONFIG_PATH=$(PREFIX_FULLPATH)/lib/pkgconfig LDFLAGS=$(RPATH_LDFLAGS) pip -v install -e ./pynodegl)
+	cp $(PREFIX)/Scripts/*.dll pynodegl/.
 endif
 
 pynodegl-deps-install: $(PREFIX_DONE) nodegl-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& pip install -r pynodegl\\requirements.txt)
-else
-	($(ACTIVATE) && pip install -r ./pynodegl/requirements.txt)
-endif
+	($(ACTIVATE) && $(PIP) install -r ./pynodegl/requirements.txt)
 
 nodegl-install: nodegl-setup
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_COMPILE) -C builddir\\libnodegl \&\& $(MESON_INSTALL) -C builddir\\libnodegl)
-else
 	($(ACTIVATE) && $(MESON_COMPILE) -C builddir/libnodegl && $(MESON_INSTALL) -C builddir/libnodegl)
-endif
 
 NODEGL_DEPS = sxplayer-install
 ifeq ($(DEBUG_GPU_CAPTURE),yes)
@@ -219,30 +188,19 @@ endif
 endif
 
 nodegl-setup: $(NODEGL_DEPS)
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP) $(NODEGL_DEBUG_OPTS) libnodegl builddir\\libnodegl)
-else
 	($(ACTIVATE) && $(MESON_SETUP) $(NODEGL_DEBUG_OPTS) libnodegl builddir/libnodegl)
-endif
 
 pkg-config-install: external-download $(PREFIX_DONE)
 ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP) -Dtests=false external\\pkgconf builddir\\pkgconf \&\& $(MESON_COMPILE) -C builddir\\pkgconf \&\& $(MESON_INSTALL) -C builddir\\pkgconf)
-	($(CMD) copy "$(PREFIX_FULLPATH)\\Scripts\\pkgconf.exe" "$(PREFIX_FULLPATH)\\Scripts\\pkg-config.exe")
+	($(ACTIVATE) && $(MESON_SETUP) -Dtests=false external/pkgconf builddir/pkgconf && $(MESON_COMPILE) -C builddir/pkgconf && $(MESON_INSTALL) -C builddir/pkgconf)
 endif
 
 sxplayer-install: external-download pkg-config-install $(PREFIX)
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP) external\\sxplayer builddir\\sxplayer \&\& $(MESON_COMPILE) -C builddir\\sxplayer \&\& $(MESON_INSTALL) -C builddir\\sxplayer)
-else
 	($(ACTIVATE) && $(MESON_SETUP) external/sxplayer builddir/sxplayer && $(MESON_COMPILE) -C builddir/sxplayer && $(MESON_INSTALL) -C builddir/sxplayer)
-endif
 
 renderdoc-install: external-download pkg-config-install $(PREFIX)
 ifeq ($(TARGET_OS),Windows)
-	$(CMD) xcopy /Y "$(RENDERDOC_DIR)\renderdoc.dll" "$(PREFIX_FULLPATH)\Scripts\."
-else
-	cp $(RENDERDOC_DIR)/renderdoc.dll $(PREFIX_FULLPATH)/bin/
+	cp external/renderdoc/renderdoc.dll $(PREFIX)/Scripts/.
 endif
 
 external-download:
@@ -280,47 +238,34 @@ MoltenVK-install: external-download $(PREFIX)
 #
 $(PREFIX_DONE):
 ifeq ($(TARGET_OS),Windows)
-	($(CMD) $(PYTHON) -m venv $(PREFIX))
-	($(ACTIVATE) \&\& pip install meson ninja)
-	$(CMD) xcopy /Y "$(VCPKG_DIR)\installed\x64-windows\tools\shaderc_shared.dll" "$(PREFIX_FULLPATH)\Scripts\."
-	$(CMD) xcopy /Y "$(VCPKG_DIR)\installed\x64-windows\bin\*.dll" "$(PREFIX_FULLPATH)\Scripts\."
+	$(PYTHON) -m venv $(PREFIX)
+	# Convert windows to unix style line endings in the activate bash script
+	# See https://bugs.python.org/issue43437
+	sed -i 's/\r$///' $(PREFIX)/Scripts/activate
+	cp $(VCPKG_DIR_WSL)/installed/x64-windows/tools/shaderc_shared.dll $(PREFIX)/Scripts/.
+	cp $(VCPKG_DIR_WSL)/installed/x64-windows/bin/*.dll $(PREFIX)/Scripts/.
+	($(ACTIVATE) && $(PIP) install meson ninja)
 else ifeq ($(TARGET_OS),MinGW-w64)
 	$(PYTHON) -m venv --system-site-packages $(PREFIX)
 else
 	$(PYTHON) -m venv $(PREFIX)
-	($(ACTIVATE) && pip install meson ninja)
+	($(ACTIVATE) && $(PIP) install meson ninja)
 endif
 	touch $(PREFIX_DONE)
 
 $(PREFIX): $(PREFIX_DONE)
 
 tests: nodegl-tests tests-setup
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& meson test $(MESON_TESTS_SUITE_OPTS) -C builddir\\tests)
-else
-	($(ACTIVATE) && meson test $(MESON_TESTS_SUITE_OPTS) -C builddir/tests)
-endif
+	($(ACTIVATE) && $(MESON) test $(MESON_TESTS_SUITE_OPTS) -C builddir/tests)
 
 tests-setup: ngl-tools-install pynodegl-utils-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP_NINJA) builddir\\tests tests)
-else
 	($(ACTIVATE) && $(MESON_SETUP) builddir/tests tests)
-endif
 
 nodegl-tests: nodegl-install
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& meson test -C builddir\\libnodegl)
-else
-	($(ACTIVATE) && meson test -C builddir/libnodegl)
-endif
+	($(ACTIVATE) && $(MESON) test -C builddir/libnodegl)
 
 nodegl-%: nodegl-setup
-ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_COMPILE) -C builddir\\libnodegl $(subst nodegl-,,$@))
-else
 	($(ACTIVATE) && $(MESON_COMPILE) -C builddir/libnodegl $(subst nodegl-,,$@))
-endif
 
 clean_py:
 	$(RM) pynodegl/nodes_def.pyx

--- a/pynodegl/setup.py
+++ b/pynodegl/setup.py
@@ -22,13 +22,15 @@
 
 from setuptools import setup, Command, Extension
 from setuptools.command.build_ext import build_ext
+import os
 
 
 class LibNodeGLConfig:
 
     PKG_LIB_NAME = 'libnodegl'
 
-    def __init__(self, pkg_config_bin='pkg-config'):
+    pkg_config_env = os.getenv('PKG_CONFIG')
+    def __init__(self, pkg_config_bin= pkg_config_env if pkg_config_env else 'pkg-config'):
         import subprocess
 
         if subprocess.call([pkg_config_bin, '--exists', self.PKG_LIB_NAME]) != 0:

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,8 @@
 project('ngl-tests', meson_version: '>= 0.56.0')
 
-ngl_test = find_program('ngl-test')
-ngl_probe = find_program('ngl-probe')
+bin_dir = get_option('prefix')/get_option('bindir')
+ngl_test = find_program('ngl-test', dirs: [ bin_dir ])
+ngl_probe = find_program('ngl-probe', dirs: [ bin_dir ])
 
 backends = []
 probe_output = run_command(ngl_probe).stdout()


### PR DESCRIPTION
Invoke windows executables from wsl bash shell directly,
instead of bash invoking command prompt, invoking the windows executable.
This allows us to unify the code across platforms.