### PR TITLE
build/windows: don't use vcpkg integrate install for pthreads support

### DIFF
--- a/.github/workflows/ci_msvc.yml
+++ b/.github/workflows/ci_msvc.yml
@@ -47,7 +47,6 @@ jobs:
           pip.exe install meson
           cd /mnt/c/vcpkg
           ./vcpkg.exe install --triplet ${{env.VCPKG_TRIPLET}} ${{env.VCPKG_INSTALL_PACKAGES}}
-          ./vcpkg.exe integrate install
 
       - name: Build
         run: |

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ endif
 
 nodegl-setup: $(NODEGL_DEPS)
 ifeq ($(TARGET_OS),Windows)
-	($(ACTIVATE) \&\& $(MESON_SETUP) $(NODEGL_DEBUG_OPTS) libnodegl builddir\\libnodegl)
+	($(ACTIVATE) \&\& $(MESON_SETUP) $(NODEGL_DEBUG_OPTS) libnodegl builddir\\libnodegl -D pthreads_dir=$(VCPKG_DIR)\\installed\\x64-windows)
 else
 	($(ACTIVATE) && $(MESON_SETUP) $(NODEGL_DEBUG_OPTS) libnodegl builddir/libnodegl)
 endif

--- a/libnodegl/meson.build
+++ b/libnodegl/meson.build
@@ -219,6 +219,17 @@ lib_deps = [
   dependency('libsxplayer', version: '>= 9.7.0'),
   dependency('threads'),
 ]
+if (cc.get_id() == 'msvc')
+  pthreads_dir = get_option('pthreads_dir')
+  pthreads_dep = declare_dependency(
+      compile_args: [ '-D_TIMESPEC_DEFINED' ],
+      include_directories: [ pthreads_dir / 'include' ],
+      link_args: [
+        '-L' + pthreads_dir / 'lib', '-lpthreadVC3',
+      ],
+    )
+  lib_deps += pthreads_dep
+endif
 
 host_cfg = hosts_cfg.get(host_system, {})
 foreach dep : host_cfg.get('deps', [])

--- a/libnodegl/meson_options.txt
+++ b/libnodegl/meson_options.txt
@@ -41,3 +41,5 @@ option('debug_opts', type: 'array', choices: ['gl', 'mem', 'scene', 'gpu_capture
 
 option('renderdoc_dir', type: 'string',
        description: 'Renderdoc directory')
+option('pthreads_dir', type: 'string',
+       description: 'pthreads directory (required on windows)')


### PR DESCRIPTION
vcpkg integrate install logic is broken.  The way it works is it adds
all libraries under installed/x64-windows/lib as linker args for all
MSVC projects.  This adds unnecessary additional libraries and slows
down the build.  See https://github.com/microsoft/vcpkg/issues/15452.
