### PR TITLE
tools/ipc: use closesocket() instead of close() on Windows

### DIFF
--- a/ngl-tools/ngl-ipc.c
+++ b/ngl-tools/ngl-ipc.c
@@ -351,7 +351,11 @@ int main(int argc, char *argv[])
         if (ret != -1)
             break;
 
+#ifdef _WIN32
+        closesocket(fd);
+#else
         close(fd);
+#endif
     }
 
     if (!rp) {


### PR DESCRIPTION
Fixes the following compile warning on the MinGW CI:
../../ngl-tools/ngl-ipc.c:354:9: warning: implicit declaration of function 'close'

This was forgotten in 139b5ec4d8072831061f2b689bc7650deb419029.