### PR TITLE
doc,ci: remove unneeded pip requirement

### DIFF
--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -17,8 +17,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew install python3 curl pkg-config sdl2 ffmpeg
-        # https://docs.brew.sh/Homebrew-and-Python
-        python3 -m pip install --upgrade pip
 
     - name: Build
       run: |

--- a/.github/workflows/ci_mingw.yml
+++ b/.github/workflows/ci_mingw.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pacman -S --noconfirm --needed git make
           pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg,python}
-          pacman -S --noconfirm --needed mingw-w64-x86_64-python3-{pillow,pip}
+          pacman -S --noconfirm --needed mingw-w64-x86_64-python3-pillow
           pacman -S --noconfirm --needed mingw-w64-x86_64-meson
 
       - name: Build

--- a/.github/workflows/ci_msvc.yml
+++ b/.github/workflows/ci_msvc.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt -y install build-essential unzip
-          pip.exe install meson
           cd /mnt/c/vcpkg
           ./vcpkg.exe install --triplet ${{env.VCPKG_TRIPLET}} ${{env.VCPKG_INSTALL_PACKAGES}}
 

--- a/doc/howto/installation.md
+++ b/doc/howto/installation.md
@@ -11,7 +11,6 @@ building and running the complete `node.gl` stack.
   - **FFmpeg** (and its libraries for compilation)
   - **Python 3.x** (you will need the package with the build headers as well,
     typically named with a `-devel` suffix on Debian based systems)
-  - **pip** (Python 3 version)
   - **Graphviz**
   - **SDL2**
 - Build with `make -jN` where `N` is the number of parallel processes
@@ -27,7 +26,7 @@ building and running the complete `node.gl` stack.
     pacman -S git make
     pacman -S mingw-w64-x86_64-{toolchain,ffmpeg,python}
     pacman -S mingw-w64-x86_64-python-watchdog
-    pacman -S mingw-w64-x86_64-python3-{pillow,pip}
+    pacman -S mingw-w64-x86_64-python3-pillow
     pacman -S mingw-w64-x86_64-pyside2-qt5
     pacman -S mingw-w64-x86_64-meson
     pacman -S mingw-w64-x86_64-graphviz


### PR DESCRIPTION
Pip is pulled from within the Python venv, it should not be required on
the host.