### PR TITLE
streamedbuffer: use correct priv_size

### DIFF
--- a/libnodegl/node_streamedbuffer.c
+++ b/libnodegl/node_streamedbuffer.c
@@ -200,7 +200,7 @@ const struct node_class ngli_streamedbuffer##class_suffix##_class = {       \
     .name      = class_name,                                                \
     .init      = streamedbuffer_init,                                       \
     .update    = streamedbuffer_update,                                     \
-    .priv_size = sizeof(struct variable_priv),                              \
+    .priv_size = sizeof(struct buffer_priv),                                \
     .params    = streamedbuffer##class_suffix##_params,                     \
     .file      = __FILE__,                                                  \
 };                                                                          \


### PR DESCRIPTION
StreamedBuffer nodes are based on struct buffer_priv not struct
variable_priv.

This was not causing any issue as the size of the varilable_priv
structure (368 bytes) is larger than the size of the buffer_priv one
(200 bytes).