### PR TITLE
gpu_capture: pass gctx to gpu_capture_create()

### DIFF
--- a/libnodegl/backends/gl/gctx_gl.c
+++ b/libnodegl/backends/gl/gctx_gl.c
@@ -393,7 +393,7 @@ static int gl_init(struct gctx *s)
     const char *var = getenv("NGL_GPU_CAPTURE");
     s->gpu_capture = var && !strcmp(var, "yes");
     if (s->gpu_capture) {
-        s->gpu_capture_ctx = gpu_capture_ctx_create();
+        s->gpu_capture_ctx = gpu_capture_ctx_create(s);
         if (!s->gpu_capture_ctx) {
             LOG(ERROR, "could not create GPU capture context");
             return NGL_ERROR_MEMORY;

--- a/libnodegl/gpu_capture.h
+++ b/libnodegl/gpu_capture.h
@@ -22,9 +22,10 @@
 #ifndef GPU_CAPTURE_H
 #define GPU_CAPTURE_H
 
+struct gctx;
 struct gpu_capture_ctx;
 
-struct gpu_capture_ctx *gpu_capture_ctx_create(void);
+struct gpu_capture_ctx *gpu_capture_ctx_create(struct gctx *s);
 int gpu_capture_init(struct gpu_capture_ctx *s);
 int gpu_capture_begin(struct gpu_capture_ctx *s);
 int gpu_capture_end(struct gpu_capture_ctx *s);

--- a/libnodegl/gpu_capture_renderdoc.c
+++ b/libnodegl/gpu_capture_renderdoc.c
@@ -41,7 +41,7 @@ struct gpu_capture_ctx {
 #endif
 };
 
-struct gpu_capture_ctx *gpu_capture_ctx_create(void)
+struct gpu_capture_ctx *gpu_capture_ctx_create(struct gctx *gctx)
 {
     struct gpu_capture_ctx *s = ngli_calloc(1, sizeof(*s));
     return s;


### PR DESCRIPTION
This will be useful later on if the capture backend needs to access to
the underlying graphics resources.