### PR TITLE
build/configure: misc

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -396,7 +396,7 @@ def _get_make_vars(cfg):
     #
     meson = 'MAKEFLAGS= meson' if _SYSTEM != 'Windows' else 'meson'
 
-    buildtype = 'debugoptimized' if cfg.args.coverage or cfg.args.buildtype == 'debug' else 'release'
+    buildtype = 'debug' if cfg.args.coverage or cfg.args.buildtype == 'debug' else 'release'
     meson_setup = [
         'setup',
         '--prefix', cfg.prefix,

--- a/configure.py
+++ b/configure.py
@@ -415,6 +415,12 @@ def _get_make_vars(cfg):
         # Workaround Debian/Ubuntu bug; see https://github.com/mesonbuild/meson/issues/5925
         meson_setup += ['--libdir=lib']
 
+    if _SYSTEM == 'Windows':
+        # Use Multithreaded DLL runtime library for debug and release configurations
+        # Third party libs are compiled in release mode
+        # Visual Studio toolchain requires all libraries to use the same runtime library
+        meson_setup += ['-Db_vscrt=md']
+
     ret = dict(
         PIP=_cmd_join(python, '-m', 'pip'),
         MESON=meson,


### PR DESCRIPTION
Use MultithreadedDLL VS runtime library.  See the commit message.
Use debug instead of debugoptimized.  See the commit message.