### PR TITLE
Hwupload improvements - part 1

### DIFF
--- a/libnodegl/backends/gl/hwupload_videotoolbox_darwin_gl.c
+++ b/libnodegl/backends/gl/hwupload_videotoolbox_darwin_gl.c
@@ -118,7 +118,7 @@ static int vt_darwin_init(struct ngl_node *node, struct sxplayer_frame * frame)
     for (int i = 0; i < 2; i++) {
         const struct texture_params *texture_params = &s->params;
 
-        struct texture_params plane_params = {
+        const struct texture_params plane_params = {
             .type             = NGLI_TEXTURE_TYPE_2D,
             .format           = i == 0 ? NGLI_FORMAT_R8_UNORM : NGLI_FORMAT_R8G8_UNORM,
             .min_filter       = texture_params->min_filter,

--- a/libnodegl/backends/gl/hwupload_videotoolbox_darwin_gl.c
+++ b/libnodegl/backends/gl/hwupload_videotoolbox_darwin_gl.c
@@ -116,9 +116,15 @@ static int vt_darwin_init(struct ngl_node *node, struct sxplayer_frame * frame)
     struct hwupload_vt_darwin *vt = hwupload->hwmap_priv_data;
 
     for (int i = 0; i < 2; i++) {
+        const struct texture_params *texture_params = &s->params;
+
         struct texture_params plane_params = {
             .type             = NGLI_TEXTURE_TYPE_2D,
             .format           = i == 0 ? NGLI_FORMAT_R8_UNORM : NGLI_FORMAT_R8G8_UNORM,
+            .min_filter       = texture_params->min_filter,
+            .mag_filter       = texture_params->mag_filter,
+            .wrap_s           = texture_params->wrap_s,
+            .wrap_t           = texture_params->wrap_t,
             .usage            = NGLI_TEXTURE_USAGE_SAMPLED_BIT,
             .rectangle        = 1,
             .external_storage = 1,

--- a/libnodegl/backends/gl/hwupload_videotoolbox_ios_gl.c
+++ b/libnodegl/backends/gl/hwupload_videotoolbox_ios_gl.c
@@ -237,10 +237,17 @@ static int vt_ios_init(struct ngl_node *node, struct sxplayer_frame *frame)
         return ret;
 
     for (int i = 0; i < format_desc.nb_planes; i++) {
-        struct texture_params plane_params = s->params;
-        plane_params.format = format_desc.planes[i].format;
-        plane_params.mipmap_filter = NGLI_MIPMAP_FILTER_NONE;
-        plane_params.usage = NGLI_TEXTURE_USAGE_SAMPLED_BIT;
+        const struct texture_params texture_params = &s->params;
+
+        const struct texture_params plane_params = {
+            .type             = NGLI_TEXTURE_TYPE_2D,
+            .format           = format_desc.planes[i].format;
+            .min_filter       = texture_params->min_filter,
+            .mag_filter       = texture_params->mag_filter,
+            .wrap_s           = texture_params->wrap_s,
+            .wrap_t           = texture_params->wrap_t,
+            .usage            = NGLI_TEXTURE_USAGE_SAMPLED_BIT,
+        };
 
         vt->planes[i] = ngli_texture_create(gpu_ctx);
         if (!vt->planes[i])

--- a/libnodegl/backends/gl/hwupload_videotoolbox_ios_gl.c
+++ b/libnodegl/backends/gl/hwupload_videotoolbox_ios_gl.c
@@ -198,13 +198,14 @@ static int support_direct_rendering(struct ngl_node *node, struct sxplayer_frame
 
     CVPixelBufferRef cvpixbuf = (CVPixelBufferRef)frame->data;
     OSType cvformat = CVPixelBufferGetPixelFormatType(cvpixbuf);
-    int direct_rendering = s->supported_image_layouts & (1 << NGLI_IMAGE_LAYOUT_NV12);
+    int direct_rendering = 1;
 
     switch (cvformat) {
     case kCVPixelFormatType_32BGRA:
     case kCVPixelFormatType_32RGBA:
         break;
     case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+        direct_rendering = s->supported_image_layouts & (1 << NGLI_IMAGE_LAYOUT_NV12);
         if (direct_rendering && s->params.mipmap_filter) {
             LOG(WARNING, "IOSurface NV12 buffers do not support mipmapping: "
                 "disabling direct rendering");

--- a/libnodegl/hwupload.c
+++ b/libnodegl/hwupload.c
@@ -145,17 +145,12 @@ static int exec_hwconv(struct ngl_node *node)
     return 0;
 }
 
-int ngli_hwupload_upload_frame(struct ngl_node *node)
+int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame)
 {
     struct ngl_ctx *ctx = node->ctx;
     const struct ngl_config *config = &ctx->config;
     struct texture_priv *s = node->priv_data;
     struct hwupload *hwupload = &s->hwupload;
-    struct media_priv *media = s->data_src->priv_data;
-    struct sxplayer_frame *frame = media->frame;
-    if (!frame)
-        return 0;
-    media->frame = NULL;
 
     if (frame->width  != hwupload->width ||
         frame->height != hwupload->height ||

--- a/libnodegl/hwupload.c
+++ b/libnodegl/hwupload.c
@@ -191,12 +191,12 @@ int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *fra
         if (!hwupload->hwconv_initialized) {
             ret = init_hwconv(node);
             if (ret < 0)
-                return ret;
+                goto end;
             hwupload->hwconv_initialized = 1;
         }
         ret = exec_hwconv(node);
         if (ret < 0)
-            return ret;
+            goto end;
         *image = hwupload->hwconv_image;
     } else {
         *image = hwupload->mapped_image;

--- a/libnodegl/hwupload.c
+++ b/libnodegl/hwupload.c
@@ -145,7 +145,7 @@ static int exec_hwconv(struct ngl_node *node)
     return 0;
 }
 
-int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame)
+int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame, struct image *image)
 {
     struct ngl_ctx *ctx = node->ctx;
     const struct ngl_config *config = &ctx->config;
@@ -197,13 +197,13 @@ int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *fra
         ret = exec_hwconv(node);
         if (ret < 0)
             return ret;
-        s->image = hwupload->hwconv_image;
+        *image = hwupload->hwconv_image;
     } else {
-        s->image = hwupload->mapped_image;
+        *image = hwupload->mapped_image;
     }
 
 end:
-    s->image.ts = frame->ts;
+    image->ts = frame->ts;
 
     if (!(hwupload->hwmap_class->flags &  HWMAP_FLAG_FRAME_OWNER))
         sxplayer_release_frame(frame);
@@ -223,7 +223,6 @@ void ngli_hwupload_uninit(struct ngl_node *node)
     }
     ngli_freep(&hwupload->hwmap_priv_data);
     hwupload->hwmap_class = NULL;
-    ngli_image_reset(&s->image);
     hwupload->pix_fmt = 0;
     hwupload->width = 0;
     hwupload->height = 0;

--- a/libnodegl/hwupload.c
+++ b/libnodegl/hwupload.c
@@ -87,7 +87,7 @@ static int init_hwconv(struct ngl_node *node)
 
     ngli_hwconv_reset(hwconv);
     ngli_image_reset(hwconv_image);
-    ngli_texture_freep(&hwupload->texture);
+    ngli_texture_freep(&hwupload->hwconv_texture);
 
     LOG(DEBUG, "converting texture '%s' from %s to rgba", node->label, hwupload->hwmap_class->name);
 
@@ -97,10 +97,10 @@ static int init_hwconv(struct ngl_node *node)
     params.height = mapped_image->params.height;
     params.usage |= NGLI_TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 
-    hwupload->texture = ngli_texture_create(gpu_ctx);
-    if (!hwupload->texture)
+    hwupload->hwconv_texture = ngli_texture_create(gpu_ctx);
+    if (!hwupload->hwconv_texture)
         return NGL_ERROR_MEMORY;
-    int ret = ngli_texture_init(hwupload->texture, &params);
+    int ret = ngli_texture_init(hwupload->hwconv_texture, &params);
     if (ret < 0)
         goto end;
 
@@ -111,7 +111,7 @@ static int init_hwconv(struct ngl_node *node)
         .color_scale = 1.f,
         .color_info = NGLI_COLOR_INFO_DEFAULTS,
     };
-    ngli_image_init(hwconv_image, &image_params, &hwupload->texture);
+    ngli_image_init(hwconv_image, &image_params, &hwupload->hwconv_texture);
 
     ret = ngli_hwconv_init(hwconv, ctx, hwconv_image, &mapped_image->params);
     if (ret < 0)
@@ -122,7 +122,7 @@ static int init_hwconv(struct ngl_node *node)
 end:
     ngli_hwconv_reset(hwconv);
     ngli_image_reset(hwconv_image);
-    ngli_texture_freep(&hwupload->texture);
+    ngli_texture_freep(&hwupload->hwconv_texture);
     return ret;
 }
 
@@ -130,7 +130,7 @@ static int exec_hwconv(struct ngl_node *node)
 {
     struct texture_priv *s = node->priv_data;
     struct hwupload *hwupload = &s->hwupload;
-    struct texture *texture = hwupload->texture;
+    struct texture *texture = hwupload->hwconv_texture;
     const struct texture_params *texture_params = &texture->params;
     struct image *mapped_image = &hwupload->mapped_image;
     struct hwconv *hwconv = &hwupload->hwconv;

--- a/libnodegl/hwupload.h
+++ b/libnodegl/hwupload.h
@@ -49,7 +49,7 @@ struct hwupload {
     struct image mapped_image;
     int require_hwconv;
     struct hwconv hwconv;
-    struct texture *texture;
+    struct texture *hwconv_texture;
     struct image hwconv_image;
     int hwconv_initialized;
 };

--- a/libnodegl/hwupload.h
+++ b/libnodegl/hwupload.h
@@ -54,7 +54,7 @@ struct hwupload {
     int hwconv_initialized;
 };
 
-int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame);
+int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame, struct image *image);
 void ngli_hwupload_uninit(struct ngl_node *node);
 
 #endif /* HWUPLOAD_H */

--- a/libnodegl/hwupload.h
+++ b/libnodegl/hwupload.h
@@ -54,7 +54,7 @@ struct hwupload {
     int hwconv_initialized;
 };
 
-int ngli_hwupload_upload_frame(struct ngl_node *node);
+int ngli_hwupload_upload_frame(struct ngl_node *node, struct sxplayer_frame *frame);
 void ngli_hwupload_uninit(struct ngl_node *node);
 
 #endif /* HWUPLOAD_H */

--- a/libnodegl/hwupload.h
+++ b/libnodegl/hwupload.h
@@ -50,6 +50,7 @@ struct hwupload {
     int require_hwconv;
     struct hwconv hwconv;
     struct texture *texture;
+    struct image hwconv_image;
     int hwconv_initialized;
 };
 

--- a/libnodegl/node_texture.c
+++ b/libnodegl/node_texture.c
@@ -351,13 +351,19 @@ static void handle_media_frame(struct ngl_node *node)
         LOG(ERROR, "could not map media frame");
 }
 
-static void handle_buffer_frame(struct ngl_node *node)
+static int handle_buffer_frame(struct ngl_node *node)
 {
     struct texture_priv *s = node->priv_data;
     struct buffer_priv *buffer = s->data_src->priv_data;
     const uint8_t *data = buffer->data;
 
-    ngli_texture_upload(s->texture, data, 0);
+    int ret = ngli_texture_upload(s->texture, data, 0);
+    if (ret < 0) {
+        LOG(ERROR, "could not upload texture buffer");
+        return ret;
+    }
+
+    return 0;
 }
 
 static int texture_update(struct ngl_node *node, double t)
@@ -381,7 +387,9 @@ static int texture_update(struct ngl_node *node, double t)
             ret = ngli_node_update(s->data_src, t);
             if (ret < 0)
                 return ret;
-            handle_buffer_frame(node);
+            ret = handle_buffer_frame(node);
+            if (ret < 0)
+                return ret;
             break;
     }
 

--- a/libnodegl/node_texture.c
+++ b/libnodegl/node_texture.c
@@ -346,7 +346,17 @@ static int texture_prefetch(struct ngl_node *node)
 
 static void handle_media_frame(struct ngl_node *node)
 {
-    int ret = ngli_hwupload_upload_frame(node);
+    struct texture_priv *s = node->priv_data;
+    struct media_priv *media = s->data_src->priv_data;
+    struct sxplayer_frame *frame = media->frame;
+    if (!frame)
+        return;
+
+    /* Transfer frame ownership to hwupload and ensure it cannot be re-used
+     * later on */
+    media->frame = NULL;
+
+    int ret = ngli_hwupload_map_frame(node, frame);
     if (ret < 0)
         LOG(ERROR, "could not map media frame");
 }

--- a/libnodegl/node_texture.c
+++ b/libnodegl/node_texture.c
@@ -356,7 +356,10 @@ static void handle_media_frame(struct ngl_node *node)
      * later on */
     media->frame = NULL;
 
-    int ret = ngli_hwupload_map_frame(node, frame);
+    /* Reset destination image */
+    ngli_image_reset(&s->image);
+
+    int ret = ngli_hwupload_upload_frame(node, frame, &s->image);
     if (ret < 0)
         LOG(ERROR, "could not map media frame");
 }


### PR DESCRIPTION
The goal of this PR is to progressively change the API of the hwupload module to move away the API from depending on the internal nodes structures. It also includes a bunch of fixes for the videotoolbox hwupload modules.