### PR TITLE
utils: add shared read for ngli_get_filesize for Windows

### DIFF
--- a/libnodegl/src/utils.c
+++ b/libnodegl/src/utils.c
@@ -181,7 +181,7 @@ void ngli_thread_set_name(const char *name)
 int ngli_get_filesize(const char *filename, int64_t *size)
 {
 #ifdef _WIN32
-    HANDLE file_handle = CreateFile(TEXT(filename), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE file_handle = CreateFile(TEXT(filename), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (file_handle == INVALID_HANDLE_VALUE)
         return NGL_ERROR_IO;
 


### PR DESCRIPTION
utils: This option under windows enable multi process to read the same file at the same time.
If we do not set this option, 2 or more ngl-desktop process running in parallels could failed to get size of asset.
No side effects.