### PR TITLE
build: add properties informations with a rc file for the dll under windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnodegl`.
 ### Fixed
 - Color channel difference in `ngl-diff` is now done in linear space
 
+### Added
+- Windows DLL information (Copyrights, Version, Name)
+
 ### Changed
 - The installed `nodes.specs` is now in `JSON` instead of `YAML`
 - The default branch is now named `main`

--- a/libnodegl/meson.build
+++ b/libnodegl/meson.build
@@ -654,6 +654,25 @@ elif host_system == 'iphone'
   lib_objc_args += '-DGLES_SILENCE_DEPRECATION'
 endif
 
+
+# Create nodegl version data for rc
+nodegl_version_cdata = configuration_data()
+nodegl_version_cdata.set('NODEGL_COPYRIGHT', 'Copyright GoPro Inc.')
+nodegl_version_cdata.set('NODEGL_MAJOR_VERSION', version_array[0])
+nodegl_version_cdata.set('NODEGL_MINOR_VERSION', version_array[1])
+nodegl_version_cdata.set('NODEGL_MICRO_VERSION', version_array[2])
+nodegl_version_cdata.set('NODEGL_VERSION', meson.project_version())
+
+# Add properties information with a rc file for the DLL under Windows
+if cc.get_id() == 'msvc'
+  nodegl_rc = configure_file(
+    input: 'nodegl.rc.in',
+    output: 'nodegl.rc',
+    configuration: nodegl_version_cdata,
+  )
+  lib_src += import('windows').compile_resources(nodegl_rc)
+endif
+
 libnodegl = library(
   'nodegl',
   lib_src,

--- a/libnodegl/nodegl.rc.in
+++ b/libnodegl/nodegl.rc.in
@@ -1,0 +1,32 @@
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION @NODEGL_MAJOR_VERSION@,@NODEGL_MINOR_VERSION@,@NODEGL_MICRO_VERSION@,0
+  PRODUCTVERSION @NODEGL_MAJOR_VERSION@,@NODEGL_MINOR_VERSION@,@NODEGL_MICRO_VERSION@,0
+  FILEFLAGSMASK 0
+  FILEFLAGS 0
+  FILEOS VOS__WINDOWS32
+  FILETYPE VFT_DLL
+  FILESUBTYPE VFT2_UNKNOWN
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "040904B0"
+      BEGIN
+	VALUE "CompanyName", "GoPro"
+	VALUE "FileDescription", "node.gl"
+	VALUE "FileVersion", "@NODEGL_VERSION@"
+	VALUE "InternalName", "nodegl-@NODEGL_MAJOR_VERSION@.dll"
+	VALUE "LegalCopyright", "@NODEGL_COPYRIGHT@"
+	VALUE "OriginalFilename", "nodegl-@NODEGL_MAJOR_VERSION@.dll"
+	VALUE "ProductName", "node.gl"
+	VALUE "ProductVersion", "@NODEGL_VERSION@"
+    VALUE "Licence", "Apache-2.0 license"
+    VALUE "Info", "https://github.com/gopro/gopro-lib-node.gl"
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0x409, 1200
+    END
+  END


### PR DESCRIPTION
Add properties informations with a rc file for the dll under Windows
- Copyrights
- Version
- Platform
- Name

It enables user or/and developer or/and tester to report easily the dll version used inside the projet.
It also enables to check if there is some mistake on distributing the dll.