### PR TITLE
tests: node.gl windows all the tests are not working

### DIFF
--- a/.github/workflows/ci_msvc.yml
+++ b/.github/workflows/ci_msvc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     env:
         VCPKG_TRIPLET: x64-windows
-        VCPKG_INSTALL_PACKAGES: opengl-registry ffmpeg[ffmpeg,ffprobe] sdl2 glslang
+        VCPKG_INSTALL_PACKAGES: opengl-registry ffmpeg[ffmpeg,ffprobe,zlib] sdl2 glslang # zlib is necessary for ffprobe and png to get "pix_fmt"
         VULKAN_SDK_VERSION: 1.3.204.1
     strategy:
       matrix:

--- a/doc/usr/howto/installation.md
+++ b/doc/usr/howto/installation.md
@@ -47,7 +47,7 @@ building and running the complete `node.gl` stack.
   `C:\vcpkg`, then from Windows PowerShell:
     ```shell
     .\bootstrap-vcpkg.bat
-    .\vcpkg.exe install --triplet x64-windows opengl-registry ffmpeg[ffmpeg,ffprobe] sdl2 glslang
+    .\vcpkg.exe install --triplet x64-windows opengl-registry ffmpeg[ffmpeg,ffprobe,zlib] sdl2 glslang
     ```
 - Add `C:\vcpkg\installed\x64-windows\tools\ffmpeg` path to your windows system
   `%PATH%` environment variable (`ffmpeg` and `ffprobe` binaries must be

--- a/tests/media.py
+++ b/tests/media.py
@@ -146,7 +146,7 @@ def media_exposed_time(cfg: SceneCfg):
     return render
 
 
-@test_fingerprint(width=1024, height=1024, nb_keyframes=30, tolerance=1)
+@test_fingerprint(width=1024, height=1024, nb_keyframes=30, tolerance=2)
 @scene(overlap_time=scene.Range(range=[0, 10], unit_base=10), dim=scene.Range(range=[1, 10]))
 def media_queue(cfg: SceneCfg, overlap_time=7.0, dim=3):
     cfg.duration = 10


### PR DESCRIPTION
tests: build ffmpeg with zlib
tests: test_fingerprint tolerance set to 2 for media_queue because of OpenGLES rendering difference under Windows.