### PR TITLE
Fix cross-compilation on macOS

### DIFF
--- a/libnodegl/meson.build
+++ b/libnodegl/meson.build
@@ -85,10 +85,7 @@ if host_system == 'windows'
 endif
 
 # Need a flag to declare if using cross compilation or not
-is_native = true
-if host_system == 'android' or host_system == 'iphone'
-  is_native = false
-endif
+is_native = not meson.is_cross_build()
 
 # This trim prefix is used to make __FILE__ starts from the source dir with
 # out-of-tree builds.


### PR DESCRIPTION
Context
-------

The macOS platform is now able to cross-compile between Intel and Arm architectures, but the build script doesn't allow it. This PR simply adds support for this use case.

Commit message
--------------

When cross-compiling on macOS, we got the following error:
> Tried to install a target for the build machine in a cross build.

The problem was that the flag `is_native` wasn't correctly set.

The proposed solution is to rely on `meson.is_cross_build()` to set the `is_native` flag, instead of manually setting it depending on the `host_system`.